### PR TITLE
Fixed #35: Can now detect and use the executable's filename

### DIFF
--- a/src/funcs.c
+++ b/src/funcs.c
@@ -33,6 +33,8 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <exec/memory.h>
+#include <workbench/startup.h>
+#include <exec/types.h>
 #include <workbench/workbench.h>
 #include <clib/graphics_protos.h>
 
@@ -43,6 +45,7 @@
 
 extern char* strdup(const char* s);
 extern struct ObjApp* app;
+extern char* executable_name;
 
 /* global variables */
 int global_filter_check = 0;
@@ -73,6 +76,7 @@ int get_title_from_slave(char* slave, char* title);
 int check_dup_title(char* title);
 int get_delimiter_position(const char* str);
 char* get_directory_name(char* str);
+char* get_executable_name(int argc, char** argv);
 
 /* structures */
 struct EasyStruct msgbox;
@@ -1867,8 +1871,8 @@ void read_tool_types()
 
 	if (icon_base = (struct Library *)OpenLibrary("icon.library", 0))
 	{
-		//TODO Is there a way to detect the executable name, instead of hard-coding it here?
-		if (disk_obj = (struct DiskObject *)GetDiskObject("PROGDIR:iGame"))
+		char* filename = strcat("PROGDIR:", executable_name);
+		if (disk_obj = (struct DiskObject *)GetDiskObject((unsigned char*)filename))
 		{
 			if (FindToolType(disk_obj->do_ToolTypes, "SCREENSHOT"))
 			{
@@ -2150,3 +2154,29 @@ char* get_directory_name(char* str)
 	return dir_name;
 }
 
+// Get the application's executable name
+char* get_executable_name(int argc, char** argv)
+{
+	struct WBStartup *argmsg;
+	struct WBArg *wb_arg;
+	BPTR olddir;
+
+	// argc is zero when run from the Workbench,
+	// positive when run from the CLI
+	if (argc == 0)
+	{
+		// in AmigaOS, argv is a pointer to the WBStartup message
+		// when argc is zero (run under the Workbench)
+		argmsg = (struct WBStartup *)argv;
+		wb_arg = argmsg->sm_ArgList;         /* head of the arg list */
+
+		executable_name = wb_arg->wa_Name;
+	}
+	else
+	{
+		// Run from the CLI
+		executable_name = argv[0];
+	}
+
+	return executable_name;
+}

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -60,7 +60,7 @@ int NOGUIGFX;
 int FILTERUSEENTER;
 int NOSCREENSHOT;
 int SAVESTATSONEXIT;
-int SCANBYDIRS;
+int TITLESFROMDIRS;
 int IntroPic = 0;
 
 /* function definitions */
@@ -1624,9 +1624,9 @@ void followthread(BPTR lock, int tab_level)
 				temptitle[n] = '\0';
 				//printf("title: [%s]\n", temptitle);
 				//strcpy (item_games->Title, temptitle);
-				if (SCANBYDIRS)
+				if (TITLESFROMDIRS)
 				{
-					// If the SCANBYDIRS tooltype is enabled, set Titles from Directory names
+					// If the TITLESFROMDIRS tooltype is enabled, set Titles from Directory names
 					char* title = get_directory_name(fullpath);
 					if (title != NULL)
 						strcpy(item_games->title, title);
@@ -1867,7 +1867,7 @@ void read_tool_types()
 	FILTERUSEENTER = 0;
 	NOSCREENSHOT = 0;
 	SAVESTATSONEXIT = 0;
-	SCANBYDIRS = 0;
+	TITLESFROMDIRS = 0;
 
 	if (icon_base = (struct Library *)OpenLibrary("icon.library", 0))
 	{
@@ -1921,9 +1921,9 @@ void read_tool_types()
 				SAVESTATSONEXIT = 1;
 			}
 
-			if (FindToolType(disk_obj->do_ToolTypes, "SCANBYDIRS"))
+			if (FindToolType(disk_obj->do_ToolTypes, "TITLESFROMDIRS"))
 			{
-				SCANBYDIRS = 1;
+				TITLESFROMDIRS = 1;
 			}
 		}
 

--- a/src/iGameMain.c
+++ b/src/iGameMain.c
@@ -21,8 +21,10 @@ struct ObjApp* app = NULL; /* Object */
 extern void AppStart();
 extern void app_stop();
 extern void read_tool_types();
+extern char* get_executable_name(int argc, char** argv);
 
 struct Library *MUIMasterBase;
+char* executable_name;
 
 void CleanExit(CONST_STRPTR s)
 {
@@ -45,7 +47,7 @@ BOOL InitApp(int argc, char **argv)
 		CleanExit("Can't initialize application\n");
 	else
 	{
-		//read tooltypes here
+		executable_name = get_executable_name(argc, argv);
 		read_tool_types();
 		AppStart();
 	}


### PR DESCRIPTION
Can now detect the executable filename, regardless if it was started from the CLI or the Workbench. Removed hard-coded reference to PROGDIR:iGame when searching for the icon file (to read the Tooltypes)