### PR TITLE
Native compiling for OS4 with MUI5 and OS4 SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ src/*.o
 iGame.0*0
 iGame_rel/iGame.info
 iGame.MOS
-iGame.MOS
+iGame.AOS4

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -21,12 +21,14 @@
             "includePath": [
                 "${workspaceFolder}/**",
                 "${VBCC}/targets/ppc-amigaos/include/",
-                "${VBCC}/NDK39/Include/include_h",
-                "${VBCC}/MUI/Developer/C/Include",
+                "${VBCC}/SDK/include/include_h",
+                "${VBCC}/SDK/MUI/C/include",
                 "${VBCC}/MCC_Guigfx/Developer/C/Include",
                 "${VBCC}/MCC_TextEditor/Developer/C/include"
             ],
-            "defines": [],
+            "defines": [
+                "__amigaos4__"
+            ],
             "compilerPath": "${VBCC}/bin/vc",
             "cStandard": "c99",
             "cppStandard": "c++98",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "Makefile.*": "makefile"
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CFLAGS_030	= -c -mcpu=68030 -noixemul -Os -fomit-frame-pointer -std=c99
 CFLAGS_040	= -c -mcpu=68040 -noixemul -Os -fomit-frame-pointer -std=c99
 CFLAGS_060	= -c -mcpu=68060 -noixemul -Os -fomit-frame-pointer -std=c99
 CFLAGS_MOS	= -c +morphos -dontwarn=-1 -O2 -c99
-CFLAGS_AOS4	= -c +aosppc -dontwarn=-1 -O2 -c99
+CFLAGS_AOS4	= -c +aosppc -dontwarn=-1 -O2 -c99 -D__USE_INLINE__
 
 DATE = $(shell date --iso=date)
 

--- a/Makefile.Windows.mak
+++ b/Makefile.Windows.mak
@@ -22,7 +22,7 @@ CFLAGS_030	= -c +aos68k -cpu=68030 -dontwarn=-1 -O2 -c99
 CFLAGS_040	= -c +aos68k -cpu=68040 -dontwarn=-1 -O2 -c99
 CFLAGS_060	= -c +aos68k -cpu=68060 -dontwarn=-1 -O2 -c99
 CFLAGS_MOS	= -c +morphos -dontwarn=-1 -O2 -c99
-CFLAGS_AOS4	= -c +aosppc -dontwarn=-1 -O2 -c99
+CFLAGS_AOS4	= -c +aosppc -dontwarn=-1 -O2 -c99 -D__USE_INLINE__
 
 DATE = $(shell date --iso=date)
 

--- a/Makefile.amigaos
+++ b/Makefile.amigaos
@@ -22,7 +22,7 @@ CFLAGS_030	= -c +aos68k -cpu=68030 -dontwarn=-1 -O2 -c99
 CFLAGS_040	= -c +aos68k -cpu=68040 -dontwarn=-1 -O2 -c99
 CFLAGS_060	= -c +aos68k -cpu=68060 -dontwarn=-1 -O2 -c99
 CFLAGS_MOS	= -c +morphos -dontwarn=-1 -O2 -c99
-CFLAGS_AOS4	= -c +aosppc -dontwarn=-1 -O2 -c99
+CFLAGS_AOS4	= -c +aosppc -dontwarn=-1 -O2 -c99 -D__USE_INLINE__
 
 ##########################################################################
 # Library builder settings
@@ -181,5 +181,5 @@ src/iGameStrings_cat_AOS4.o: src/iGameStrings_cat.c
 ##########################################################################
 
 clean:
-	delete iGame iGame.030 iGame.040 iGame.060 iGame.MOS src/funcs.o src/funcs_030.o src/funcs_040.o src/funcs_060.o src/funcs_MOS.o src/iGameGui.o src/iGameGui_030.o src/iGameGui_040.o src/iGameGui_060.o src/iGameGui_MOS.o src/iGameMain.o src/iGameMain_030.o src/iGameMain_040.o src/iGameMain_060.o src/iGameMain_MOS.o src/strdup.o src/strdup_030.o src/strdup_040.o src/strdup_060.o src/strdup_MOS.o src/iGameStrings_cat.o src/iGameStrings_cat_030.o src/iGameStrings_cat_040.o src/iGameStrings_cat_060.o src/iGameStrings_cat_MOS.o
+	delete iGame iGame.030 iGame.040 iGame.060 iGame.MOS iGame.AOS4 $(OBJS) $(OBJS_030) $(OBJS_040) $(OBJS_060) $(OBJS_MOS) $(OBJS_AOS4)
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -22,7 +22,7 @@ CFLAGS_030	= -c +aos68k -cpu=68030 -dontwarn=-1 -O2 -c99
 CFLAGS_040	= -c +aos68k -cpu=68040 -dontwarn=-1 -O2 -c99
 CFLAGS_060	= -c +aos68k -cpu=68060 -dontwarn=-1 -O2 -c99
 CFLAGS_MOS	= -c +morphos -dontwarn=-1 -O2 -c99
-CFLAGS_AOS4	= -c +aosppc -dontwarn=-1 -O2 -c99
+CFLAGS_OS4	= -c +aosppc -dontwarn=-1 -O2
 
 DATE = $(shell date --iso=date)
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -17,12 +17,13 @@ all: iGame
 CC			= vc
 LINK		= vc
 INCLUDES	= -I$(NDK_INC) -I$(MUI38_INC)
+INCLUDES_AOS4 = -I$(SDK_INC) -I$(MUI50_INC)
 CFLAGS		= -c +aos68k -dontwarn=-1 -O2 -c99
 CFLAGS_030	= -c +aos68k -cpu=68030 -dontwarn=-1 -O2 -c99
 CFLAGS_040	= -c +aos68k -cpu=68040 -dontwarn=-1 -O2 -c99
 CFLAGS_060	= -c +aos68k -cpu=68060 -dontwarn=-1 -O2 -c99
 CFLAGS_MOS	= -c +morphos -dontwarn=-1 -O2 -c99
-CFLAGS_OS4	= -c +aosppc -dontwarn=-1 -O2
+CFLAGS_OS4	= -c +aosppc -dontwarn=-1 -O2 -D__USE_INLINE__
 
 DATE = $(shell date --iso=date)
 
@@ -117,7 +118,7 @@ src/iGameMain_040.o: src/iGameMain.c
 
 src/strdup_040.o: src/strdup.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strdup.c
-	
+
 src/iGameStrings_cat_040.o: src/iGameStrings_cat.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameStrings_cat.c
 
@@ -164,19 +165,19 @@ src/iGameStrings_cat_MOS.o: src/iGameStrings_cat.c
 ##########################################################################
 
 src/funcs_AOS4.o: src/funcs.c
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/funcs.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/funcs.c
 
 src/iGameGUI_AOS4.o: src/iGameGUI.c src/iGameGUI.h
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/iGameGUI.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/iGameGUI.c
 
 src/iGameMain_AOS4.o: src/iGameMain.c
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/iGameMain.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/iGameMain.c
 
 src/strdup_AOS4.o: src/strdup.c
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/strdup.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/strdup.c
 
 src/iGameStrings_cat_AOS4.o: src/iGameStrings_cat.c
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/iGameStrings_cat.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/iGameStrings_cat.c
 
 ##########################################################################
 # generic build options
@@ -198,11 +199,13 @@ release:
 	make iGame.040 -f Makefile.linux
 	make iGame.060 -f Makefile.linux
 	make iGame.MOS -f Makefile.linux
+	make iGame.AOS4 -f Makefile.linux
 	cp iGame iGame_rel/iGame-$(DATE)/
 	cp iGame.030 iGame_rel/iGame-$(DATE)/
 	cp iGame.040 iGame_rel/iGame-$(DATE)/
 	cp iGame.060 iGame_rel/iGame-$(DATE)/
 	cp iGame.MOS iGame_rel/iGame-$(DATE)/
+	cp iGame.AOS4 iGame_rel/iGame=$(DATE)/
 	cp required_files/genres iGame_rel/iGame-$(DATE)/
 	cp required_files/igame.iff iGame_rel/iGame-$(DATE)/
 	cp required_files/iGame.info iGame_rel/iGame-$(DATE)/

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -16,13 +16,14 @@ all: iGame
 ##########################################################################
 CC			= vc
 LINK		= vc
-INCLUDES	= -I/opt/vbcc/targets/m68k-amigaos/ndk-include/ -I/opt/vbcc/targets/m68k-amigaos/include/mui/
+INCLUDES	= -I$(NDK_INC) -I$(MUI38_INC)
+INCLUDES_AOS4 = -I$(SDK_INC) -I$(MUI50_INC)
 CFLAGS		= -c +aos68k -dontwarn=-1 -O2 -c99
 CFLAGS_030	= -c +aos68k -cpu=68030 -dontwarn=-1 -O2 -c99
 CFLAGS_040	= -c +aos68k -cpu=68040 -dontwarn=-1 -O2 -c99
 CFLAGS_060	= -c +aos68k -cpu=68060 -dontwarn=-1 -O2 -c99
 CFLAGS_MOS	= -c +morphos -dontwarn=-1 -O2 -c99
-CFLAGS_AOS4	= -c +aosppc -dontwarn=-1 -O2 -c99
+CFLAGS_AOS4	= -c +aosppc -dontwarn=-1 -O2 -c99 -D__USE_INLINE__
 
 DATE = $(shell date --iso=date)
 
@@ -117,7 +118,7 @@ src/iGameMain_040.o: src/iGameMain.c
 
 src/strdup_040.o: src/strdup.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strdup.c
-	
+
 src/iGameStrings_cat_040.o: src/iGameStrings_cat.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameStrings_cat.c
 
@@ -164,19 +165,19 @@ src/iGameStrings_cat_MOS.o: src/iGameStrings_cat.c
 ##########################################################################
 
 src/funcs_AOS4.o: src/funcs.c
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/funcs.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/funcs.c
 
 src/iGameGUI_AOS4.o: src/iGameGUI.c src/iGameGUI.h
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/iGameGUI.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/iGameGUI.c
 
 src/iGameMain_AOS4.o: src/iGameMain.c
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/iGameMain.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/iGameMain.c
 
 src/strdup_AOS4.o: src/strdup.c
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/strdup.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/strdup.c
 
 src/iGameStrings_cat_AOS4.o: src/iGameStrings_cat.c
-	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/iGameStrings_cat.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/iGameStrings_cat.c
 
 ##########################################################################
 # generic build options
@@ -198,11 +199,13 @@ release:
 	make iGame.040 -f Makefile.linux
 	make iGame.060 -f Makefile.linux
 	make iGame.MOS -f Makefile.linux
+	make iGame.AOS4 -f Makefile.linux
 	cp iGame iGame_rel/iGame-$(DATE)/
 	cp iGame.030 iGame_rel/iGame-$(DATE)/
 	cp iGame.040 iGame_rel/iGame-$(DATE)/
 	cp iGame.060 iGame_rel/iGame-$(DATE)/
 	cp iGame.MOS iGame_rel/iGame-$(DATE)/
+	cp iGame.AOS4 iGame_rel/iGame=$(DATE)/
 	cp required_files/genres iGame_rel/iGame-$(DATE)/
 	cp required_files/igame.iff iGame_rel/iGame-$(DATE)/
 	cp required_files/iGame.info iGame_rel/iGame-$(DATE)/

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1,9 +1,9 @@
 /*
   funcs.c
   Misc functions for iGame
-  
+
   Copyright (c) 2019, Emmanuel Vasilakis and contributors
-  
+
   This file is part of iGame.
 
   iGame is free software: you can redistribute it and/or modify
@@ -20,28 +20,49 @@
   along with iGame. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <clib/exec_protos.h>
-#include <clib/dos_protos.h>
-#include <clib/alib_protos.h>
-#include <clib/icon_protos.h>
+/* MUI */
 #include <libraries/mui.h>
 #include <MUI/Guigfx_mcc.h>
 #include <MUI/TextEditor_mcc.h>
+
+/* Prototypes */
+#include <clib/alib_protos.h>
+
+#if defined(__amigaos4__)
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <proto/icon.h>
+#include <proto/graphics.h>
+#include <proto/muimaster.h>
+#else
+#include <clib/exec_protos.h>
+#include <clib/dos_protos.h>
+#include <clib/icon_protos.h>
 #include <clib/muimaster_protos.h>
+#include <clib/graphics_protos.h>
+#endif
+
+/* System */
+#include <dos/dos.h>
+#if defined(__amigaos4__)
+#include <dos/obsolete.h>
+#endif
+#include <exec/memory.h>
+#include <exec/types.h>
+#include <libraries/asl.h>
+#include <workbench/startup.h>
+#include <workbench/workbench.h>
+
+/* ANSI C */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <exec/memory.h>
-#include <workbench/startup.h>
-#include <exec/types.h>
-#include <workbench/workbench.h>
-#include <clib/graphics_protos.h>
+
 
 #include "iGameGUI.h"
 #include "iGameExtern.h"
 #include "iGameStrings_cat.h"
-#include <libraries/asl.h>
 
 extern char* strdup(const char* s);
 extern struct ObjApp* app;
@@ -75,6 +96,7 @@ void strip_path(const char* path, char* naked_path);
 char* get_slave_from_path(char* slave, int start, char* path);
 void read_tool_types();
 void check_for_wbrun();
+void list_show_favorites(char* str);
 
 /* structures */
 struct EasyStruct msgbox;
@@ -178,6 +200,7 @@ void load_settings(const char* filename)
 	}
 	current_settings = (igame_settings *)calloc(1, sizeof(igame_settings));
 
+	// TODO: Maybe it would be a good idea to lock the file before open it
 	const BPTR fpsettings = Open((CONST_STRPTR)filename, MODE_OLDFILE);
 	if (fpsettings)
 	{
@@ -220,6 +243,7 @@ void load_settings(const char* filename)
 		// No "igame.prefs" file found, fallback to reading Tooltypes
 		read_tool_types();
 	}
+
 	if (file_line)
 		free(file_line);
 }
@@ -412,7 +436,7 @@ void load_genres(const char* filename)
 		app->CY_AddGameGenreContent[i + 1] = NULL;
 		set(app->CY_AddGameGenre, MUIA_Cycle_Entries, app->CY_AddGameGenreContent);
 
-		
+
 
 		Close(fpgenres);
 	}
@@ -1273,10 +1297,10 @@ void game_properties()
 	char* slave = AllocMem(256 * sizeof(char), MEMF_CLEAR);
 
 	// Check if any of them failed
-	if (helperstr == NULL 
-		|| fullpath == NULL 
-		|| str2 == NULL 
-		|| path == NULL 
+	if (helperstr == NULL
+		|| fullpath == NULL
+		|| str2 == NULL
+		|| path == NULL
 		|| naked_path == NULL
 		|| slave == NULL)
 	{
@@ -1298,7 +1322,7 @@ void game_properties()
 		msg_box((const char*)GetMBString(MSG_SelectGameFromList));
 		return;
 	}
-	
+
 	int i;
 	struct DiskObject* disk_obj;
 	char* tool_type;
@@ -1606,7 +1630,7 @@ void game_properties_ok()
 				FreeMem(m, sizeof(struct FileInfoBlock));
 			CloseLibrary(icon_base);
 		}
-		
+
 		CurrentDir(oldlock);
 
 		// Cleanup the memory allocations
@@ -2372,14 +2396,17 @@ void get_screen_size(int* width, int* height)
 
 void read_tool_types()
 {
-	struct Library* icon_base;
-	struct DiskObject* disk_obj;
+	struct Library *icon_base;
+	struct DiskObject *disk_obj;
 
 	int screen_width, screen_height;
+	unsigned char filename[32];
 
 	if ((icon_base = (struct Library *)OpenLibrary((CONST_STRPTR)ICON_LIBRARY, 0)))
 	{
-		char* filename = strcat(PROGDIR, executable_name);
+		strcpy(filename, PROGDIR);
+		strcat(filename, executable_name);
+
 		if ((disk_obj = GetDiskObject((STRPTR)filename)))
 		{
 			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_SCREENSHOT))
@@ -2433,7 +2460,6 @@ void read_tool_types()
 			if (FindToolType(disk_obj->do_ToolTypes, (STRPTR)TOOLTYPE_NOSIDEPANEL))
 				current_settings->hide_side_panel = 1;
 		}
-
 		CloseLibrary(icon_base);
 	}
 
@@ -2656,7 +2682,7 @@ const char* get_directory_name(const char* str)
 }
 
 // Get the application's executable name
-const char* get_executable_name(int argc, char** argv)
+const char *get_executable_name(int argc, char **argv)
 {
 	// argc is zero when run from the Workbench,
 	// positive when run from the CLI
@@ -2736,7 +2762,7 @@ void joy_left()
 
   DoMethod(app->LV_GamesList, MUIM_List_GetEntry, MUIV_List_GetEntry_Active, &curr_game);
   get(app->LV_GamesList, MUIA_List_Active, &ind);
-  
+
   if (curr_game == NULL || strlen(curr_game) == 0)
     {
       set(app->LV_GamesList, MUIA_List_Active, MUIV_List_Active_Top);
@@ -2746,7 +2772,7 @@ void joy_left()
   DoMethod(app->LV_GamesList, MUIM_List_GetEntry, ind--, &prev_game);
   if (prev_game == NULL)
 	return;
-  
+
   while (toupper(curr_game[0]) == toupper(prev_game[0]))
     {
       DoMethod(app->LV_GamesList, MUIM_List_GetEntry, ind--, &prev_game);
@@ -2755,7 +2781,7 @@ void joy_left()
     }
 
   last_game = prev_game;
-  
+
   while (toupper(last_game[0]) == toupper(prev_game[0]))
     {
       DoMethod(app->LV_GamesList, MUIM_List_GetEntry, ind--, &prev_game);
@@ -2773,7 +2799,7 @@ void joy_right()
 
   DoMethod(app->LV_GamesList, MUIM_List_GetEntry, MUIV_List_GetEntry_Active, &curr_game);
   get(app->LV_GamesList, MUIA_List_Active, &ind);
-  
+
   if (curr_game == NULL || strlen(curr_game) == 0)
     {
       set(app->LV_GamesList, MUIA_List_Active, MUIV_List_Active_Top);
@@ -2783,7 +2809,7 @@ void joy_right()
   DoMethod(app->LV_GamesList, MUIM_List_GetEntry, ind++, &next_game);
   if (next_game == NULL)
 	return;
-  
+
   while (toupper(curr_game[0]) == toupper(next_game[0]))
     {
       DoMethod(app->LV_GamesList, MUIM_List_GetEntry, ind++, &next_game);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -49,6 +49,9 @@
 #endif
 #include <exec/memory.h>
 #include <exec/types.h>
+#if defined(__amigaos4__)
+#define ASL_PRE_V38_NAMES
+#endif
 #include <libraries/asl.h>
 #include <workbench/startup.h>
 #include <workbench/workbench.h>

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -89,7 +89,7 @@ struct ObjApp * CreateApp(void)
 	static const struct Hook MenuScanHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)scan_repositories, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook MenuOpenListHook = { { NULL,NULL }, (HOOKFUNC)MenuOpenList, NULL, NULL };
+	static const struct Hook MenuOpenListHook = { { NULL,NULL }, (HOOKFUNC)open_list, NULL, NULL };
 #else
 	static const struct Hook MenuOpenListHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)open_list, NULL };
 #endif
@@ -179,42 +179,42 @@ struct ObjApp * CreateApp(void)
 	static const struct Hook RepoRemoveHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)repo_remove, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook SettingFilterUseEnterChangedHook = { { NULL,NULL }, (HOOKFUNC)SettingFilterUseEnterChanged, NULL, NULL };
+	static const struct Hook SettingFilterUseEnterChangedHook = { { NULL,NULL }, (HOOKFUNC)setting_filter_use_enter_changed, NULL, NULL };
 #else
 	static const struct Hook SettingFilterUseEnterChangedHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)setting_filter_use_enter_changed, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook SettingSaveStatsOnExitChangedHook = { { NULL,NULL }, (HOOKFUNC)SettingSaveStatsOnExitChanged, NULL, NULL };
+	static const struct Hook SettingSaveStatsOnExitChangedHook = { { NULL,NULL }, (HOOKFUNC)setting_save_stats_on_exit_changed, NULL, NULL };
 #else
 	static const struct Hook SettingSaveStatsOnExitChangedHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)setting_save_stats_on_exit_changed, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook SettingSmartSpacesChangedHook = { { NULL,NULL }, (HOOKFUNC)SettingSmartSpacesChanged, NULL, NULL };
+	static const struct Hook SettingSmartSpacesChangedHook = { { NULL,NULL }, (HOOKFUNC)setting_smart_spaces_changed, NULL, NULL };
 #else
 	static const struct Hook SettingSmartSpacesChangedHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)setting_smart_spaces_changed, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook SettingTitlesFromChangedHook = { { NULL,NULL }, (HOOKFUNC)SettingTitlesFromChanged, NULL, NULL };
+	static const struct Hook SettingTitlesFromChangedHook = { { NULL,NULL }, (HOOKFUNC)setting_titles_from_changed, NULL, NULL };
 #else
 	static const struct Hook SettingTitlesFromChangedHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)setting_titles_from_changed, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook SettingHideScreenshotChangedHook = { { NULL,NULL }, (HOOKFUNC)SettingHideScreenshotChanged, NULL, NULL };
+	static const struct Hook SettingHideScreenshotChangedHook = { { NULL,NULL }, (HOOKFUNC)setting_hide_screenshot_changed, NULL, NULL };
 #else
 	static const struct Hook SettingHideScreenshotChangedHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)setting_hide_screenshot_changed, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook SettingNoGuiGfxChangedHook = { { NULL,NULL }, (HOOKFUNC)SettingNoGuiGfxChanged, NULL, NULL };
+	static const struct Hook SettingNoGuiGfxChangedHook = { { NULL,NULL }, (HOOKFUNC)setting_no_guigfx_changed, NULL, NULL };
 #else
 	static const struct Hook SettingNoGuiGfxChangedHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)setting_no_guigfx_changed, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook SettingScreenshotSizeChangedHook = { { NULL,NULL }, (HOOKFUNC)SettingScreenshotSizeChanged, NULL, NULL };
+	static const struct Hook SettingScreenshotSizeChangedHook = { { NULL,NULL }, (HOOKFUNC)setting_screenshot_size_changed, NULL, NULL };
 #else
 	static const struct Hook SettingScreenshotSizeChangedHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)setting_screenshot_size_changed, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook SettingsSaveHook = { { NULL,NULL }, (HOOKFUNC)SettingsSave, NULL, NULL };
+	static const struct Hook SettingsSaveHook = { { NULL,NULL }, (HOOKFUNC)settings_save, NULL, NULL };
 #else
 	static const struct Hook SettingsSaveHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)settings_save, NULL };
 #endif

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -22,27 +22,34 @@
 
 #define MUI_OBSOLETE
 
+/* MUI */
 #include <libraries/mui.h>
-
-#include <clib/alib_protos.h>
-#include <proto/muimaster.h>
-#include <proto/exec.h>
-
 #include <MUI/Guigfx_mcc.h>
 #include <MUI/TextEditor_mcc.h>
-#include <libraries/gadtools.h> /* for Barlabel in MenuItem */
-#include <exec/memory.h>
+
+/* Prototypes */
+#include <clib/alib_protos.h>
+#include <proto/exec.h>
 #include <proto/icon.h>
 #include <proto/asl.h>
-#include <dos/dos.h>
+#include <proto/muimaster.h>
 
-#include "version.h"
+/* System */
+#include <libraries/gadtools.h> /* for Barlabel in MenuItem */
+#include <exec/memory.h>
+#include <dos/dos.h>
+#if defined(__amigaos4__)
+#include <dos/obsolete.h>
+#endif
+
+/* ANSI C */
 #include <string.h>
 
 #ifndef MAKE_ID
 #define MAKE_ID(a,b,c,d) ((ULONG) (a)<<24 | (ULONG) (b)<<16 | (ULONG) (c)<<8 | (ULONG) (d))
 #endif
 
+#include "version.h"
 #include "iGameGUI.h"
 #include "iGameExtern.h"
 #include "iGameStrings_cat.h"
@@ -74,7 +81,7 @@ struct ObjApp * CreateApp(void)
 	APTR	GR_TitlesFrom, Space_TitlesFrom, GR_SmartSpaces, Space_SmartSpaces;
 	APTR	LA_SmartSpaces, GR_Misc;
 	APTR	LA_SaveStatsOnExit, LA_FilterUseEnter, LA_StartWithFavorites;
-	APTR    LA_HideSidepanel;
+	APTR	LA_HideSidepanel;
 	APTR	GR_SettingsButtons, Space_SettingsButtons1, Space_SettingsButtons2;
 #if defined(__amigaos4__)
 	static const struct Hook MenuScanHook = { { NULL,NULL }, (HOOKFUNC)scan_repositories, NULL, NULL };


### PR DESCRIPTION
This pull request fixes a few problems, and makes iGame to compile for AmigaOS 4 native with OS4 53.30 SDK and MUI 5.0 2019R4 SDK. There are some overrides on obsolete functions that should be addressed in the future, and openings of libraries, like MuimasterFace, that should be done manually. Also, there are some libraries closings and checks. This needs to be applied to more libraries, so to provide more info to the users.

A screenshot of iGame running under AmigaOS 4 natively
![iGame_OS4](https://user-images.githubusercontent.com/14014909/79387888-52c01a80-7f64-11ea-9608-4864931aa61f.png)
