### PR TITLE
Show "Unknown" genre in genres list

### DIFF
--- a/src/funcs.c
+++ b/src/funcs.c
@@ -394,6 +394,8 @@ void load_genres(const char* filename)
 			DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, item_genres->genre, MUIV_List_Insert_Sorted);
 		}
 
+		DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_UnknownGenre), MUIV_List_Insert_Bottom);
+
 		for (i = 0; i < no_of_genres; i++)
 		{
 			DoMethod(app->LV_GenresList, MUIM_List_GetEntry, i + 5, &app->CY_PropertiesGenreContent[i]);

--- a/src/iGameStrings_cat.c
+++ b/src/iGameStrings_cat.c
@@ -118,7 +118,7 @@ struct FC_String iGameStrings_Strings[100] = {
     { (STRPTR) "OK", 50 },
     { (STRPTR) "Cancel", 51 },
     { (STRPTR) "About iGame", 52 },
-    { (STRPTR) "Emmanuel Vasilakis (mrzammler@mm.st)\n\nContributors:\nDimitris Panokostas (midwan@gmail.com)\n\n", 53 },
+    { (STRPTR) "Emmanuel Vasilakis (mrzammler@mm.st)\n\nContributors:\nDimitris Panokostas (midwan@gmail.com)\nChris Charabaruk (chris+igame@charabaruk.com)\n\n", 53 },
     { (STRPTR) "OK", 54 },
     { (STRPTR) "iGame Settings", 55 },
     { (STRPTR) "Hide Screenshots", 56 },


### PR DESCRIPTION
Make it easy for users to see which games haven't been categorized into any genre by adding "Unknown" to the bottom of the genres list.

Closes #77