### PR TITLE
Keep image aspect for screenshot/icon when Guigfx is used

### DIFF
--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1110,7 +1110,7 @@ void game_click()
 				{
 					app->IM_GameImage_1 = GuigfxObject, MUIA_Guigfx_FileName, naked_path,
 					                                  MUIA_Guigfx_Quality, MUIV_Guigfx_Quality_Best,
-					                                  MUIA_Guigfx_ScaleMode, NISMF_SCALEFREE,
+					                                  MUIA_Guigfx_ScaleMode, NISMF_SCALEFREE | NISMF_KEEPASPECT_PICTURE,
 					                                  MUIA_Guigfx_Transparency, 0,
 					                                  MUIA_Frame, MUIV_Frame_ImageButton,
 					                                  MUIA_FixHeight, current_settings->screenshot_height,
@@ -1145,7 +1145,7 @@ void game_click()
 					{
 						app->IM_GameImage_1 = GuigfxObject, MUIA_Guigfx_FileName, DEFAULT_SCREENSHOT_FILE,
 						                                  MUIA_Guigfx_Quality, MUIV_Guigfx_Quality_Best,
-						                                  MUIA_Guigfx_ScaleMode, NISMF_SCALEFREE,
+						                                  MUIA_Guigfx_ScaleMode, NISMF_SCALEFREE | NISMF_KEEPASPECT_PICTURE,
 						                                  MUIA_Guigfx_Transparency, 0,
 						                                  MUIA_Frame, MUIV_Frame_ImageButton,
 						                                  MUIA_FixHeight, current_settings->screenshot_height,

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -307,7 +307,7 @@ struct ObjApp * CreateApp(void)
 				object->IM_GameImage_0 = GuigfxObject,
 					MUIA_Guigfx_FileName, DEFAULT_SCREENSHOT_FILE,
 					MUIA_Guigfx_Quality, MUIV_Guigfx_Quality_Best,
-					MUIA_Guigfx_ScaleMode, NISMF_SCALEFREE,
+					MUIA_Guigfx_ScaleMode, NISMF_SCALEFREE | NISMF_KEEPASPECT_PICTURE,
 					MUIA_Frame, MUIV_Frame_ImageButton,
 					MUIA_FixHeight, current_settings->screenshot_height,
 					MUIA_FixWidth, current_settings->screenshot_width,


### PR DESCRIPTION
This change keeps the proper aspect ratio for screenshots/icons displayed in the sidebar, without stretching outside of the set image bounds in settings. There's no change for when Guigfx is disabled, since in that situation the native size of the screenshot/icon image is used anyway.

The image is simply boxed within the frame due to GuigfxObject getting a fixed height and width. I tried using MUIA_MaxHeight and MUI_MaxWidth but it turned out to squeeze and shrink the image instead.

Fixes #72 