### PR TITLE
Added checks and error messages for all the required libraries

### DIFF
--- a/src/funcs.c
+++ b/src/funcs.c
@@ -186,14 +186,14 @@ void apply_settings()
 	set(app->CH_StartWithFavorites, MUIA_Selected, current_settings->start_with_favorites);
 }
 
-void load_settings(const char* filename)
+igame_settings* load_settings(const char* filename)
 {
 	const int buffer_size = 512;
 	STRPTR file_line = malloc(buffer_size * sizeof(char));
 	if (file_line == NULL)
 	{
 		msg_box((const char*)GetMBString(MSG_NotEnoughMemory));
-		return;
+		return NULL;
 	}
 
 	if (current_settings != NULL)
@@ -249,6 +249,8 @@ void load_settings(const char* filename)
 
 	if (file_line)
 		free(file_line);
+
+	return current_settings;
 }
 
 void load_games_list(const char* filename)

--- a/src/iGameMain.c
+++ b/src/iGameMain.c
@@ -177,7 +177,7 @@ BOOL init_app(int argc, char** argv)
 	executable_name = get_executable_name(argc, argv);
 	iGameSettings = load_settings(DEFAULT_SETTINGS_FILE);
 
-	if (!iGameSettings->no_guigfx)
+	if (!iGameSettings->no_guigfx && !iGameSettings->hide_screenshots)
 	{
 		RenderLibBase = OpenLibrary((CONST_STRPTR)"render.library", 30);
 		if (RenderLibBase == NULL)


### PR DESCRIPTION
Added checks and error messages for all the required libraries and minimum versions on some of them. Also, there was a serious bug fixed when someone tried to run iGame without having MUI installed. This bug crashed the whole system.

Also, the libraries are checked based on the configuration, as well. So, if the user has NOGUIGFX enabled, it will not check for GuiGfx libraries.