### PR TITLE
Pass path_only as a non-const char pointer

### DIFF
--- a/src/funcs.c
+++ b/src/funcs.c
@@ -2948,16 +2948,16 @@ void open_current_dir()
 		msg_box((const char*)GetMBString(MSG_SelectGameFromList));
 		return;
 	}
-	
+
 	path_only = get_directory_path(item_games->path);
 	if(!path_only)
 	{
 		msg_box((const char*)GetMBString(MSG_DirectoryNotFound));
 		return;
 	}
-	
+
 	//Open path directory
-	OpenWorkbenchObject(path_only);
+	OpenWorkbenchObject((char *)path_only);
 	free(path_only); // get_directory_path uses malloc()
 
 }


### PR DESCRIPTION
Silence a compile warning from vbcc by explicitly casting the const out when passing a game's drawer path to OpenWorkbenchObject.

Fixes #89