### PR TITLE
Check slave and info file names without case sensitivity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,12 @@ LIBFLAGS_AOS4	= +aosppc -lamiga -lauto -o
 ##########################################################################
 # Object files which are part of iGame
 ##########################################################################
-OBJS		= src/iGameGUI.o src/iGameMain.o src/funcs.o  src/strdup.o src/iGameStrings_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strdup_030.o src/iGameStrings_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strdup_040.o src/iGameStrings_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strdup_060.o src/iGameStrings_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
-OBJS_AOS4	= src/funcs_AOS4.o src/iGameGUI_AOS4.o src/iGameMain_AOS4.o src/strdup_AOS4.o src/iGameStrings_cat_AOS4.o
+OBJS		= src/iGameGUI.o src/iGameMain.o src/funcs.o src/strcasestr.o src/strdup.o src/iGameStrings_cat.o
+OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strcasestr_030.o src/strdup_030.o src/iGameStrings_cat_030.o
+OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strcasestr_040.o src/strdup_040.o src/iGameStrings_cat_040.o
+OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strcasestr_060.o src/strdup_060.o src/iGameStrings_cat_060.o
+OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strcasestr_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
+OBJS_AOS4	= src/funcs_AOS4.o src/iGameGUI_AOS4.o src/iGameMain_AOS4.o src/strcasestr_AOS4.o src/strdup_AOS4.o src/iGameStrings_cat_AOS4.o
 
 ##########################################################################
 # Rule for building
@@ -77,6 +77,9 @@ src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h
 src/iGameMain.o: src/iGameMain.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr.o: src/strcasestr.c
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup.o: src/strdup.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strdup.c
 
@@ -95,6 +98,9 @@ src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_030.o: src/iGameMain.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_030.o: src/strcasestr.c
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_030.o: src/strdup.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strdup.c
@@ -115,6 +121,9 @@ src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_040.o: src/iGameMain.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_040.o: src/strcasestr.c
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_040.o: src/strdup.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strdup.c
 
@@ -133,6 +142,9 @@ src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_060.o: src/iGameMain.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_060.o: src/strcasestr.c
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_060.o: src/strdup.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strdup.c
@@ -153,6 +165,9 @@ src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_MOS.o: src/iGameMain.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_MOS.o: src/strcasestr.c
+	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_MOS.o: src/strdup.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/strdup.c
 
@@ -172,6 +187,9 @@ src/iGameGUI_AOS4.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_AOS4.o: src/iGameMain.c
 	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_AOS4.o: src/strcasestr.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_AOS4.o: src/strdup.c
 	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/strdup.c
 
@@ -183,7 +201,7 @@ src/iGameStrings_cat_AOS4.o: src/iGameStrings_cat.c
 ##########################################################################
 
 clean:
-	rm iGame iGame.* src/funcs*.o src/iGameGUI*.o src/iGameMain*.o src/strdup*.o src/iGameStrings_cat*.o
+	rm iGame iGame.* src/funcs*.o src/iGameGUI*.o src/iGameMain*.o src/strcasestr*.o src/strdup*.o src/iGameStrings_cat*.o
 
 # pack everything in a nice lha file
 release:

--- a/Makefile.Windows.mak
+++ b/Makefile.Windows.mak
@@ -37,12 +37,12 @@ LIBFLAGS_AOS4	= +aosppc -lamiga -lauto -o
 ##########################################################################
 # Object files which are part of the GLFW library
 ##########################################################################
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strdup.o src/iGameStrings_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strdup_030.o src/iGameStrings_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strdup_040.o src/iGameStrings_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strdup_060.o src/iGameStrings_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
-OBJS_AOS4	= src/funcs_AOS4.o src/iGameGUI_AOS4.o src/iGameMain_AOS4.o src/strdup_AOS4.o src/iGameStrings_cat_AOS4.o
+OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strcasestr.o src/strdup.o src/iGameStrings_cat.o
+OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strcasestr_030.o src/strdup_030.o src/iGameStrings_cat_030.o
+OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strcasestr_040.o src/strdup_040.o src/iGameStrings_cat_040.o
+OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strcasestr_060.o src/strdup_060.o src/iGameStrings_cat_060.o
+OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strcasestr_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
+OBJS_AOS4	= src/funcs_AOS4.o src/iGameGUI_AOS4.o src/iGameMain_AOS4.o src/strcasestr_AOS4.o src/strdup_AOS4.o src/iGameStrings_cat_AOS4.o
 
 ##########################################################################
 # Rule for building library
@@ -77,6 +77,9 @@ src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h
 src/iGameMain.o: src/iGameMain.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr.o: src/strcasestr.c
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup.o: src/strdup.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strdup.c
 
@@ -95,6 +98,9 @@ src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_030.o: src/iGameMain.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_030.o: src/strcasestr.c
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_030.o: src/strdup.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strdup.c
@@ -115,6 +121,9 @@ src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_040.o: src/iGameMain.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_040.o: src/strcasestr.c
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_040.o: src/strdup.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strdup.c
 
@@ -133,6 +142,9 @@ src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_060.o: src/iGameMain.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_060.o: src/strcasestr.c
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_060.o: src/strdup.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strdup.c
@@ -153,6 +165,9 @@ src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_MOS.o: src/iGameMain.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_MOS.o: src/strcasestr.c
+	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_MOS.o: src/strdup.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/strdup.c
 
@@ -172,6 +187,9 @@ src/iGameGUI_AOS4.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_AOS4.o: src/iGameMain.c
 	$(CC) $(CFLAGS_AOS4) -o $@ src/iGameMain.c
 
+src/strcasestr_AOS4.o: src/strcasestr.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_AOS4.o: src/strdup.c
 	$(CC) $(CFLAGS_AOS4) -o $@ src/strdup.c
 
@@ -183,6 +201,6 @@ src/iGameStrings_cat_AOS4.o: src/iGameStrings_cat.c
 ##########################################################################
 
 clean:
-	del iGame iGame.* src\funcs*.o src\iGameGUI*.o src\iGameMain*.o src\strdup*.o src\iGameStrings_cat*.o
+	del iGame iGame.* src\funcs*.o src\iGameGUI*.o src\iGameMain*.o src\strcasestr*.o src\strdup*.o src\iGameStrings_cat*.o
 
 

--- a/Makefile.amigaos
+++ b/Makefile.amigaos
@@ -35,12 +35,12 @@ LIBFLAGS_AOS4	= +aosppc -lamiga -lauto -o
 ##########################################################################
 # Object files which are part of the GLFW library
 ##########################################################################
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strdup.o src/iGameStrings_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strdup_030.o src/iGameStrings_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strdup_040.o src/iGameStrings_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strdup_060.o src/iGameStrings_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
-OBJS_AOS4	= src/funcs_AOS4.o src/iGameGUI_AOS4.o src/iGameMain_AOS4.o src/strdup_AOS4.o src/iGameStrings_cat_AOS4.o
+OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strcasestr.o src/strdup.o src/iGameStrings_cat.o
+OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strcasestr_030.o src/strdup_030.o src/iGameStrings_cat_030.o
+OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strcasestr_040.o src/strdup_040.o src/iGameStrings_cat_040.o
+OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strcasestr_060.o src/strdup_060.o src/iGameStrings_cat_060.o
+OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strcasestr_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
+OBJS_AOS4	= src/funcs_AOS4.o src/iGameGUI_AOS4.o src/iGameMain_AOS4.o src/strcasestr_AOS4.o src/strdup_AOS4.o src/iGameStrings_cat_AOS4.o
 
 ##########################################################################
 # Rule for building library
@@ -75,6 +75,9 @@ src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain.o: src/iGameMain.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr.o: src/strcasestr.c
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup.o: src/strdup.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strdup.c
 
@@ -93,6 +96,9 @@ src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_030.o: src/iGameMain.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_030.o: src/strcasestr.c
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_030.o: src/strdup.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strdup.c
@@ -113,6 +119,9 @@ src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_040.o: src/iGameMain.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_040.o: src/strcasestr.c
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_040.o: src/strdup.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strdup.c
 
@@ -131,6 +140,9 @@ src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_060.o: src/iGameMain.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_060.o: src/strcasestr.c
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_060.o: src/strdup.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strdup.c
@@ -151,6 +163,9 @@ src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_MOS.o: src/iGameMain.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_MOS.o: src/strcasestr.c
+	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_MOS.o: src/strdup.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/strdup.c
 
@@ -169,6 +184,9 @@ src/iGameGUI_AOS4.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_AOS4.o: src/iGameMain.c
 	$(CC) $(CFLAGS_AOS4) -o $@ src/iGameMain.c
+
+src/strcasestr_AOS4.o: src/strcasestr.c
+	$(CC) $(CFLAGS_AOS4) -o $@ src/strcasestr.c
 
 src/strdup_AOS4.o: src/strdup.c
 	$(CC) $(CFLAGS_AOS4) -o $@ src/strdup.c

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -65,12 +65,12 @@ LIBFLAGS_OS4	= +aosppc -lamiga -lauto -o
 ##########################################################################
 # Object files which are part of iGame
 ##########################################################################
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strdup.o src/iGameStrings_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strdup_030.o src/iGameStrings_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strdup_040.o src/iGameStrings_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strdup_060.o src/iGameStrings_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
-OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strdup_OS4.o src/iGameStrings_cat_OS4.o
+OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strcasestr.o src/strdup.o src/iGameStrings_cat.o
+OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strcasestr_030.o src/strdup_030.o src/iGameStrings_cat_030.o
+OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strcasestr_040.o src/strdup_040.o src/iGameStrings_cat_040.o
+OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strcasestr_060.o src/strdup_060.o src/iGameStrings_cat_060.o
+OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strcasestr_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
+OBJS_OS4	= src/funcs_OS4.o src/iGameGUI_OS4.o src/iGameMain_OS4.o src/strcasestr_OS4.o src/strdup_OS4.o src/iGameStrings_cat_OS4.o
 
 ##########################################################################
 # Rule for building
@@ -105,6 +105,9 @@ src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h
 src/iGameMain.o: src/iGameMain.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr.o: src/strcasestr.c
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup.o: src/strdup.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strdup.c
 
@@ -123,6 +126,9 @@ src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_030.o: src/iGameMain.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_030.o: src/strcasestr.c
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_030.o: src/strdup.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strdup.c
@@ -143,6 +149,9 @@ src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_040.o: src/iGameMain.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_040.o: src/strcasestr.c
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_040.o: src/strdup.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strdup.c
 
@@ -161,6 +170,9 @@ src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_060.o: src/iGameMain.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_060.o: src/strcasestr.c
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_060.o: src/strdup.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strdup.c
@@ -181,6 +193,9 @@ src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_MOS.o: src/iGameMain.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameMain.c
 
+src/strcasestr_MOS.o: src/strcasestr.c
+	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strcasestr.c
+
 src/strdup_MOS.o: src/strdup.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strdup.c
 
@@ -200,6 +215,9 @@ src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_OS4.o: src/iGameMain.c
 	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameMain.c
 
+src/strcasestr_OS4.o: src/strcasestr.c
+	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strcasestr.c
+
 src/strdup_OS4.o: src/strdup.c
 	$(CC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strdup.c
 
@@ -211,7 +229,7 @@ src/iGameStrings_cat_OS4.o: src/iGameStrings_cat.c
 ##########################################################################
 
 clean:
-	rm iGame iGame.* src/funcs*.o src/iGameGUI*.o src/iGameMain*.o src/strdup*.o src/iGameStrings_cat*.o
+	rm iGame iGame.* src/funcs*.o src/iGameGUI*.o src/iGameMain*.o src/strcasestr*.o src/strdup*.o src/iGameStrings_cat*.o
 
 release:
 	cp required_files iGame-$(DRONE_TAG) -r

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -37,12 +37,12 @@ LIBFLAGS_AOS4	= +aosppc -lamiga -lauto -o
 ##########################################################################
 # Object files which are part of iGame
 ##########################################################################
-OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strdup.o src/iGameStrings_cat.o
-OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strdup_030.o src/iGameStrings_cat_030.o
-OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strdup_040.o src/iGameStrings_cat_040.o
-OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strdup_060.o src/iGameStrings_cat_060.o
-OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
-OBJS_AOS4	= src/funcs_AOS4.o src/iGameGUI_AOS4.o src/iGameMain_AOS4.o src/strdup_AOS4.o src/iGameStrings_cat_AOS4.o
+OBJS		= src/funcs.o src/iGameGUI.o src/iGameMain.o src/strcasestr.o src/strdup.o src/iGameStrings_cat.o
+OBJS_030	= src/funcs_030.o src/iGameGUI_030.o src/iGameMain_030.o src/strcasestr_030.o src/strdup_030.o src/iGameStrings_cat_030.o
+OBJS_040	= src/funcs_040.o src/iGameGUI_040.o src/iGameMain_040.o src/strcasestr_040.o src/strdup_040.o src/iGameStrings_cat_040.o
+OBJS_060	= src/funcs_060.o src/iGameGUI_060.o src/iGameMain_060.o src/strcasestr_060.o src/strdup_060.o src/iGameStrings_cat_060.o
+OBJS_MOS	= src/funcs_MOS.o src/iGameGUI_MOS.o src/iGameMain_MOS.o src/strcasestr_MOS.o src/strdup_MOS.o src/iGameStrings_cat_MOS.o
+OBJS_AOS4	= src/funcs_AOS4.o src/iGameGUI_AOS4.o src/iGameMain_AOS4.o src/strcasestr_AOS4.o src/strdup_AOS4.o src/iGameStrings_cat_AOS4.o
 
 ##########################################################################
 # Rule for building
@@ -77,6 +77,9 @@ src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/version.h
 src/iGameMain.o: src/iGameMain.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr.o: src/strcasestr.c
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup.o: src/strdup.c
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strdup.c
 
@@ -95,6 +98,9 @@ src/iGameGUI_030.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_030.o: src/iGameMain.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_030.o: src/strcasestr.c
+	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_030.o: src/strdup.c
 	$(CC) $(CFLAGS_030) $(INCLUDES) -o $@ src/strdup.c
@@ -115,6 +121,9 @@ src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_040.o: src/iGameMain.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_040.o: src/strcasestr.c
+	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_040.o: src/strdup.c
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strdup.c
 
@@ -133,6 +142,9 @@ src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h
 
 src/iGameMain_060.o: src/iGameMain.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
+
+src/strcasestr_060.o: src/strcasestr.c
+	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strcasestr.c
 
 src/strdup_060.o: src/strdup.c
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strdup.c
@@ -153,6 +165,9 @@ src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_MOS.o: src/iGameMain.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/iGameMain.c
 
+src/strcasestr_MOS.o: src/strcasestr.c
+	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_MOS.o: src/strdup.c
 	$(CC) $(CFLAGS_MOS) $(INCLUDES) -o $@ src/strdup.c
 
@@ -172,6 +187,9 @@ src/iGameGUI_AOS4.o: src/iGameGUI.c src/iGameGUI.h
 src/iGameMain_AOS4.o: src/iGameMain.c
 	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/iGameMain.c
 
+src/strcasestr_AOS4.o: src/strcasestr.c
+	$(CC) $(CFLAGS_AOS4) $(INCLUDES) -o $@ src/strcasestr.c
+
 src/strdup_AOS4.o: src/strdup.c
 	$(CC) $(CFLAGS_AOS4) $(INCLUDES_AOS4) -o $@ src/strdup.c
 
@@ -183,7 +201,7 @@ src/iGameStrings_cat_AOS4.o: src/iGameStrings_cat.c
 ##########################################################################
 
 clean:
-	rm iGame iGame.* src/funcs*.o src/iGameGUI*.o src/iGameMain*.o src/strdup*.o src/iGameStrings_cat*.o
+	rm iGame iGame.* src/funcs*.o src/iGameGUI*.o src/iGameMain*.o src/strcasestr*.o src/strdup*.o src/iGameStrings_cat*.o
 
 # pack everything in a nice lha file
 release:

--- a/helper_tools/update_titles.c
+++ b/helper_tools/update_titles.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 extern char* strdup(const char* s);
+extern char* strcasestr(const char *haystack, const char *needle);
 
 typedef struct games
 {
@@ -348,7 +349,7 @@ int main()
 	for (item_games = games; item_games != NULL; item_games = item_games->next)
 	{
 		//only if it is a slave file ;-)
-		if (strstr(item_games->path, ".slave") || strstr(item_games->path, ".Slave"))
+		if (strcasestr(item_games->path, ".slave"))
 		{
 			if (!get_title_from_slave(item_games->path, helperstr))
 			{

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -68,6 +68,7 @@
 #include "iGameStrings_cat.h"
 
 extern char* strdup(const char* s);
+extern char* strcasestr(const char *haystack, const char *needle);
 extern struct ObjApp* app;
 extern char* executable_name;
 
@@ -1081,7 +1082,7 @@ void scan_repositories()
 		{
 			//only apply the not exists hack to slaves that are in the current repos, that will be scanned later
 			//Binaries (that are added through add game) should be handled afterwards
-			if (strstr(item_games->path, ".slave") || strlen(item_games->path) == 0)
+			if (strcasestr(item_games->path, ".slave") || strlen(item_games->path) == 0)
 				item_games->exists = 0;
 			else
 				item_games->exists = 1;
@@ -1176,7 +1177,7 @@ void game_click()
 			BPTR fp = Open((CONST_STRPTR)naked_path, MODE_OLDFILE);
 			if (!fp) //no igame.iff, try .info and newicons
 			{
-				if (strstr(path, ".slave")) //check for whdload game
+				if (strcasestr(path, ".slave")) //check for whdload game
 				{
 					path[strlen(path) - 6] = '\0';
 					sprintf(naked_path, "%s.info", (const char*)path);
@@ -1890,7 +1891,7 @@ void follow_thread(BPTR lock, int tab_level)
 		//make m->fib_FileName to lower
 		const int kp = strlen((char *)m->fib_FileName);
 		for (int s = 0; s < kp; s++) m->fib_FileName[s] = tolower(m->fib_FileName[s]);
-		if (strstr(m->fib_FileName, ".slave"))
+		if (strcasestr(m->fib_FileName, ".slave"))
 		{
 			NameFromLock(lock, (unsigned char*)str, 511);
 			sprintf(fullpath, "%s/%s", str, m->fib_FileName);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -963,7 +963,7 @@ void launch_game()
 
 			while ((success = ExNext(lock, m)))
 			{
-				if (strstr(m->fib_FileName, ".info"))
+				if (strcasestr(m->fib_FileName, ".info"))
 				{
 					NameFromLock(lock, (unsigned char*)str2, 512);
 					sprintf(fullpath, "%s/%s", str2, m->fib_FileName);
@@ -1491,7 +1491,7 @@ void game_properties()
 
 		while ((success = ExNext(lock, m)))
 		{
-			if (strstr(m->fib_FileName, ".info"))
+			if (strcasestr(m->fib_FileName, ".info"))
 			{
 				NameFromLock(lock, (unsigned char*)str2, 512);
 				sprintf(fullpath, "%s/%s", str2, m->fib_FileName);
@@ -1659,7 +1659,7 @@ void game_properties_ok()
 
 			while (ExNext(lock, m))
 			{
-				if (strstr(m->fib_FileName, ".info"))
+				if (strcasestr(m->fib_FileName, ".info"))
 				{
 					NameFromLock(lock, (unsigned char*)str2, 512);
 					sprintf(fullpath, "%s/%s", str2, m->fib_FileName);

--- a/src/strcasestr.c
+++ b/src/strcasestr.c
@@ -1,0 +1,30 @@
+/*
+ * strcasestr() implementation for AmigaOS
+ *
+ * Cribbed from https://stackoverflow.com/a/45109082/5697 and renamed from
+ * stristr() to strcasestr() to match GCC function of same name
+ */
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *strcasestr(const char *haystack, const char *needle)
+{
+	int c = tolower((unsigned char)*needle);
+	if (c == '\0')
+		return (char *)haystack;
+
+	for (; *haystack; haystack++) {
+		if (tolower((unsigned char)*haystack) == c) {
+			for (size_t i = 0;;) {
+				if (needle[++i] == '\0')
+					return (char *)haystack;
+				if (tolower((unsigned char)haystack[i]) != tolower((unsigned char)needle[i]))
+					break;
+			}
+		}
+	}
+
+	return NULL;
+}


### PR DESCRIPTION
This takes care of the case-sensitivity issue for slave and icon filenames in (originally mentioned in https://github.com/MrZammler/iGame/issues/74#issuecomment-680142638) that leads to slaves added via "Add non-WHDLoad Game" in the menu not getting their icon recognized for image and tooltypes. I've added a case-insensitive `strstr()` implementation (named here `strcasestr()` to match with the name of a similar function from GCC's C library) and use it wherever `strstr()` has been used to check for a .slave or .info extension on files before.

One instance of `strstr()` has not been updated to use `strcasestr()` to check if the file is a slave, due to the fact that we have already lower-cased the filename beforehand:

https://github.com/MrZammler/iGame/blob/fe9949edb75a711d1baab576d2492f2f92bc67ba/src/funcs.c#L918-L920

Fixes #97