### PR TITLE
issue-139: Wrong tooltypes in Games prevent running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 - Fixed install script on MorphOS
 - Fixed usage of Catalog files (thanks coldacid)
+- Fixed starting whdload games that have tooltypes start with the characters »«.=#!
 
 ## iGame 2.0 - 2020-10-16
 This release includes all the fixes and changes of the 2.0 beta releases below.

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -990,6 +990,12 @@ void launch_game()
 								if (tool_type[0] == '*') continue;
 								if (tool_type[0] == ';') continue;
 								if (tool_type[0] == '\0') continue;
+								if (tool_type[0] == -69) continue; // »
+								if (tool_type[0] == -85) continue; // «
+								if (tool_type[0] == '.') continue;
+								if (tool_type[0] == '=') continue;
+								if (tool_type[0] == '#') continue;
+								if (tool_type[0] == '!') continue;
 
 								/* Must check here for numerical values */
 								/* Those (starting with $ should be transformed to dec from hex) */


### PR DESCRIPTION
For this fix added the tooltypes' first characters to the ignore list, as well as a few more that might be found in games' icons.
Fixes #139 