### PR TITLE
Look for icon for non-slave games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Gathered the strings methods into one separate file. This is work that needs to be done so to make funcs.c smaller. Also merged the strcasestr.c and strdup.c files.
 - Moved the filesystem methods to a separate file.
+- Now shows the icon image for non-WHDLoad games that do not have a screenshot file, if the Info datatype is installed.
 
 ## iGame 2.1b2 - [2021-03-15]
 ### Added

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1192,6 +1192,14 @@ static char *get_screenshot_path(char *game_title)
 		return screenshot_path;
 	}
 
+	// Return the executable icon from the game folder, if it exists
+	snprintf(screenshot_path, sizeof(char) * MAX_PATH_SIZE, "%s.info", path);
+	if(check_path_exists(screenshot_path) && checkImageDatatype(screenshot_path))
+	{
+		FreeVec(path);
+		return screenshot_path;
+	}
+
 	// Return the default image from iGame folder, if exists
 	if(check_path_exists(DEFAULT_SCREENSHOT_FILE))
 	{


### PR DESCRIPTION
Show the icon of a non-WHDLoad game when no screenshot image is present in the game drawer. This means that regular executable games can be displayed in iGame just like WHDLoad executed games.

closes #82