### PR TITLE
Resync makefiles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
         "Makefile.*": "makefile",
+        "*.inc": "makefile",
         "*.h": "c"
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -59,19 +59,11 @@ include make_includes/rules.inc
 ##########################################################################
 # catalog files
 ##########################################################################
-src/iGame_cat.c: catalogs/iGame.cd catalogs/C_c.sd
-	cd catalogs && flexcat iGame.cd ../src/iGame_cat.c=C_c.sd
 
-src/iGame_cat.h: catalogs/iGame.cd catalogs/C_h.sd
-	cd catalogs && flexcat iGame.cd ../src/iGame_cat.h=C_h.sd
+include make_includes/catalogs.inc
 
 catalogs/%/iGame.catalog: catalogs/%/iGame.ct catalogs/iGame.cd
-	flexcat catalogs/iGame.cd $< CATALOG $@
-
-catalog_files := $(patsubst %/iGame.ct,%/iGame.catalog,$(wildcard catalogs/*/iGame.ct))
-catalog_dirs := $(dir $(catalog_files))
-
-catalogs: $(catalog_files)
+	flexcat catalogs/iGame.cd $< CATALOG $@ FILL QUIET || exit 0
 
 ##########################################################################
 # object files (generic 000)

--- a/Makefile.Windows.mak
+++ b/Makefile.Windows.mak
@@ -59,18 +59,11 @@ include make_includes/rules.inc
 ##########################################################################
 # catalog files
 ##########################################################################
-src/iGame_cat.c: catalogs/iGame.cd catalogs/C_c.sd
-	cd catalogs && flexcat iGame.cd ../src/iGame_cat.c=C_c.sd
 
-src/iGame_cat.h: catalogs/iGame.cd catalogs/C_h.sd
-	cd catalogs && flexcat iGame.cd ../src/iGame_cat.h=C_h.sd
+include make_includes/catalogs.inc
 
 catalogs/%/iGame.catalog: catalogs/%/iGame.ct catalogs/iGame.cd
-	flexcat catalogs/iGame.cd $< CATALOG $@
-
-catalog_files := $(patsubst %/iGame.ct,%/iGame.catalog,$(wildcard catalogs/*/iGame.ct))
-
-catalogs: $(catalog_files)
+	flexcat catalogs/iGame.cd $< CATALOG $@ FILL QUIET
 
 ##########################################################################
 # object files (generic 000)

--- a/Makefile.amigaos
+++ b/Makefile.amigaos
@@ -60,18 +60,11 @@ include make_includes/rules.inc
 ##########################################################################
 # Rules for generating catalog files
 ##########################################################################
-src/iGame_cat.c: catalogs/iGame.cd catalogs/C_c.sd
-	cd catalogs && flexcat iGame.cd /src/iGame_cat.c=C_c.sd
 
-src/iGame_cat.h: catalogs/iGame.cd catalogs/C_h.sd
-	cd catalogs && flexcat iGame.cd /src/iGame_cat.h=C_h.sd
+include make_includes/catalogs.inc
 
 catalogs/%/iGame.catalog: catalogs/%/iGame.ct catalogs/iGame.cd
-	flexcat catalogs/iGame.cd $< CATALOG $@
-
-catalog_files := $(patsubst %/iGame.ct,%/iGame.catalog,$(wildcard catalogs/*/iGame.ct))
-
-catalogs: $(catalog_files)
+	flexcat catalogs/iGame.cd $< CATALOG $@ FILL QUIET
 
 ##########################################################################
 # object files (generic 000)

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -84,16 +84,11 @@ include make_includes/rules.inc
 ##########################################################################
 # catalog files
 ##########################################################################
-src/iGame_strings.h: catalogs/iGame.cd catalogs/CatComp_h.sd
-	cd catalogs && flexcat iGame.cd ../src/iGame_strings.h=CatComp_h.sd
+
+include make_includes/catalogs.inc
 
 catalogs/%/iGame.catalog: catalogs/%/iGame.ct catalogs/iGame.cd
 	flexcat catalogs/iGame.cd $< CATALOG $@ FILL QUIET || exit 0
-
-catalog_files := $(patsubst %/iGame.ct,%/iGame.catalog,$(wildcard catalogs/*/iGame.ct))
-catalog_dirs := $(dir $(catalog_files))
-
-catalogs: $(catalog_files)
 
 ##########################################################################
 # object files (generic 000)

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -59,19 +59,11 @@ include make_includes/rules.inc
 ##########################################################################
 # catalog files
 ##########################################################################
-src/iGame_cat.c: catalogs/iGame.cd catalogs/C_c.sd
-	cd catalogs && flexcat iGame.cd ../src/iGame_cat.c=C_c.sd
 
-src/iGame_cat.h: catalogs/iGame.cd catalogs/C_h.sd
-	cd catalogs && flexcat iGame.cd ../src/iGame_cat.h=C_h.sd
+include make_includes/catalogs.inc
 
 catalogs/%/iGame.catalog: catalogs/%/iGame.ct catalogs/iGame.cd
-	flexcat catalogs/iGame.cd $< CATALOG $@
-
-catalog_files := $(patsubst %/iGame.ct,%/iGame.catalog,$(wildcard catalogs/*/iGame.ct))
-catalog_dirs := $(dir $(catalog_files))
-
-catalogs: $(catalog_files)
+	flexcat catalogs/iGame.cd $< CATALOG $@ FILL QUIET || exit 0
 
 ##########################################################################
 # object files (generic 000)

--- a/make_includes/catalogs.inc
+++ b/make_includes/catalogs.inc
@@ -1,0 +1,10 @@
+##########################################################################
+# catalog files
+##########################################################################
+src/iGame_strings.h: catalogs/iGame.cd catalogs/CatComp_h.sd
+	cd catalogs && flexcat iGame.cd ../src/iGame_strings.h=CatComp_h.sd
+
+catalog_files := $(patsubst %/iGame.ct,%/iGame.catalog,$(wildcard catalogs/*/iGame.ct))
+catalog_dirs := $(dir $(catalog_files))
+
+catalogs: $(catalog_files)


### PR DESCRIPTION
The change to iGame_strings.h from iGame_cat.c and iGame_cat.h was made only in the Docker makefile. This brings the other makefiles into sync by moving as much of the catalog rules into a shared include file as possible. Unfortunately we can't be sure that the shell OR operator is present or functional on Windows or Amiga OS, so the rule to build the actual catalog files themselves still has to be declared in each makefile individually.

This also updates VS Code config to treat the .inc files as makefiles so that proper syntax functionality is present in that editor.