### PR TITLE
Introducing Semantic versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Changed
 - Removed completely the Tooltypes. Now iGame defaults to the optimal settings and uses only the settings file to change its behaviour.
+- Now if the file "envarc:igame.prefs" exists then this is used by iGame, instead of the one that exists at the PROGDIR:. This way multiple iGame instances will have common settings (#173)
+- Introducing semantic versioning. No beta versions any more. Now the versions will have three digits based on MAJOR.MINOR.PATCH pattern. More info at https://semver.org/
 
 ## iGame 2.1 - [2022-06-04]
 ### Changed

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -18,26 +18,21 @@ all: iGame
 DATEISO = $(shell date --iso=date)
 DATESTR = $(shell date "+%Y%m%d")
 
+DRONE_TAG = v2.2.0
+
 # DRONE_TAG is set by Drone CI/CD
 # Parse the repo tag to different defines, that will be used while
 # compiling iGame
 #
-# The tags should be like v(MAJOR).(MINOR) or v(MAJOR).(MINOR)b(BETA)
-# in example v2.1 or v2.0b5
+# The tags should be like v(MAJOR).(MINOR).(PATCH)
+# in example v2.2.0
 #
 ifneq ($(origin DRONE_TAG),undefined)
 	MAJOR = $(patsubst v%,%,$(firstword $(subst ., ,$(DRONE_TAG))))
+	MINOR = $(word 2, $(subst ., ,$(DRONE_TAG)))
+	PATCH = $(word 3, $(subst ., ,$(DRONE_TAG)))
 
-	ifeq ($(findstring b,$(DRONE_TAG)), b)
-		MINOR = $(lastword $(subst ., , $(firstword $(subst b, ,$(DRONE_TAG)))))
-		BETA = $(lastword $(subst b, ,$(DRONE_TAG)))
-
-		VERS_FLAGS = -DMAJOR_VERS=$(MAJOR) -DMINOR_VERS=$(MINOR) -DBETA_VERS=$(BETA) -DRELEASE_DATE=$(DATEISO)
-	else
-		MINOR = $(lastword $(subst ., ,$(DRONE_TAG)))
-
-		VERS_FLAGS = -DMAJOR_VERS=$(MAJOR) -DMINOR_VERS=$(MINOR) -DRELEASE_DATE=$(DATEISO)
-	endif
+	VERS_FLAGS = -DMAJOR_VERS=$(MAJOR) -DMINOR_VERS=$(MINOR) -DPATCH_VERS=$(PATCH) -DRELEASE_DATE=$(DATEISO)
 else
 	VERS_FLAGS = -DRELEASE_DATE=$(DATEISO)
 endif

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -18,8 +18,6 @@ all: iGame
 DATEISO = $(shell date --iso=date)
 DATESTR = $(shell date "+%Y%m%d")
 
-DRONE_TAG = v2.2.0
-
 # DRONE_TAG is set by Drone CI/CD
 # Parse the repo tag to different defines, that will be used while
 # compiling iGame

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -110,20 +110,14 @@ struct ObjApp *CreateApp(void)
 	translateMenu(MenuMainWin);
 
 	snprintf(version_string, sizeof(version_string),
-		"%s v%d.%d"
-#ifdef BETA_VERS
-		"b%d"
-#endif
-		, GetMBString(MSG_WI_MainWindow),
-		MAJOR_VERS, MINOR_VERS
-#ifdef BETA_VERS
-		, BETA_VERS
-#endif
+		"%s v%d.%d.%d",
+		GetMBString(MSG_WI_MainWindow),
+		MAJOR_VERS, MINOR_VERS, PATCH_VERS
 	);
 
 	snprintf(about_text, sizeof(about_text),
-		"%s (%s)\n%s %s\n\nCopyright 2005-2021\n%s"
-		, version_string, STR(RELEASE_DATE), GetMBString(MSG_compiledForAboutWin), STR(CPU_VERS), GetMBString(MSG_TX_About)
+		"%s (%s)\n%s %s\n\nCopyright 2005-%d\n%s"
+		, version_string, STR(RELEASE_DATE), GetMBString(MSG_compiledForAboutWin), STR(CPU_VERS), COPY_END_YEAR, GetMBString(MSG_TX_About)
 	);
 
 	APTR	MNMainOpenList, MNMainSaveList, MNMainSaveListAs;

--- a/src/version.h
+++ b/src/version.h
@@ -25,19 +25,19 @@
 #endif
 
 #ifndef MINOR_VERS
-#define MINOR_VERS 0
+#define MINOR_VERS 2
+#endif
+
+#ifndef PATCH_VERS
+#define PATCH_VERS 0
 #endif
 
 #ifndef RELEASE_DATE
-#define RELEASE_DATE "2020"
+#define RELEASE_DATE "2022"
 #endif
+
+#define COPY_END_YEAR 2022
 
 #ifndef VERSION
-
-#ifndef BETA_VERS
-#define VERSION "$VER: iGame v" STR(MAJOR_VERS) "." STR(MINOR_VERS) " for " STR(CPU_VERS) " (" STR(RELEASE_DATE) ")"
-#else
-#define VERSION "$VER: iGame v" STR(MAJOR_VERS) "." STR(MINOR_VERS) "b" STR(BETA_VERS) " for " STR(CPU_VERS) " (" STR(RELEASE_DATE) ")"
-#endif
-
+#define VERSION "$VER: iGame v" STR(MAJOR_VERS) "." STR(MINOR_VERS) "." STR(PATCH_VERS) " for " STR(CPU_VERS) " (" STR(RELEASE_DATE) ")"
 #endif


### PR DESCRIPTION

Change the versioning of iGame to follow the Semantic versioning. No more beta versions will be released. The version will have 3 digits which will be MAJOR.MINOR.PATCH. Minor versions will be increased when new features are released. When a release will have mainly fixes there is going to be a change at the PATCH digit.

More info about Semantic Versioning https://semver.org/
