### PR TITLE
Enhance Makefile.docker removing duplicated code

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,3 @@
----
 kind: pipeline
 type: docker
 name: compile-tests
@@ -11,38 +10,38 @@ steps:
   pull: always
   image: walkero/docker4amigavbcc:latest-m68k
   commands:
-    - make -f Makefile.docker
-    - make -f Makefile.docker iGame.030
-    - make -f Makefile.docker iGame.040
-    - make -f Makefile.docker iGame.060
+  - make -f Makefile.docker CPU=000
+  - make -f Makefile.docker CPU=030
+  - make -f Makefile.docker CPU=040
+  - make -f Makefile.docker CPU=060
 - name: compile-os4
   pull: always
   image: walkero/docker4amigavbcc:latest-ppc
   commands:
-    - make -f Makefile.docker iGame.OS4
+  - make -f Makefile.docker CPU=OS4
 - name: compile-mos
   pull: always
   image: walkero/docker4amigavbcc:latest-mos
   commands:
-    - make -f Makefile.docker iGame.MOS
+  - make -f Makefile.docker CPU=MOS
 - name: create-release-lha
   image: walkero/docker4amigavbcc:latest-m68k
   commands:
-    - make -f Makefile.docker release
+  - make -f Makefile.docker release
   depends_on:
-    - compile-m68k
-    - compile-os4
-    - compile-mos
+  - compile-m68k
+  - compile-os4
+  - compile-mos
 
 trigger:
   branch:
-    include:
-    - master
-    - develop
+  include:
+  - master
+  - develop
   event:
-    include:
-    - push
-    - pull_request
+  include:
+  - push
+  - pull_request
 ---
 kind: pipeline
 type: docker
@@ -56,40 +55,40 @@ steps:
   pull: always
   image: walkero/docker4amigavbcc:latest-m68k
   commands:
-    - make -f Makefile.docker
-    - make -f Makefile.docker iGame.030
-    - make -f Makefile.docker iGame.040
-    - make -f Makefile.docker iGame.060
+  - make -f Makefile.docker CPU=000
+  - make -f Makefile.docker CPU=030
+  - make -f Makefile.docker CPU=040
+  - make -f Makefile.docker CPU=060
 - name: compile-os4
   pull: always
   image: walkero/docker4amigavbcc:latest-ppc
   commands:
-    - make -f Makefile.docker iGame.OS4
+  - make -f Makefile.docker CPU=OS4
 - name: compile-mos
   pull: always
   image: walkero/docker4amigavbcc:latest-mos
   commands:
-    - make -f Makefile.docker iGame.MOS
+  - make -f Makefile.docker CPU=MOS
 - name: create-release-lha
   image: walkero/docker4amigavbcc:latest-m68k
   commands:
-    - make -f Makefile.docker release
+  - make -f Makefile.docker release
   depends_on:
-    - compile-m68k
-    - compile-os4
-    - compile-mos
+  - compile-m68k
+  - compile-os4
+  - compile-mos
 - name: deploy-all-binary
   image: plugins/github-release
   settings:
-    api_key:
-      from_secret: GITHUB_RELEASE_API_KEY
-    files:
-      - "iGame-*.lha"
-    title: "iGame release ${DRONE_TAG}"
+  api_key:
+    from_secret: GITHUB_RELEASE_API_KEY
+  files:
+    - "iGame-*.lha"
+  title: "iGame release ${DRONE_TAG}"
   depends_on:
-    - create-release-lha
+  - create-release-lha
 
 trigger:
   event:
-    include:
-    - tag
+  include:
+  - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -35,14 +35,16 @@ steps:
 
 trigger:
   branch:
-  include:
-  - master
-  - develop
+    include:
+    - master
+    - develop
   event:
-  include:
-  - push
-  - pull_request
+    include:
+    - push
+    - pull_request
+
 ---
+
 kind: pipeline
 type: docker
 name: compile-release-bytag
@@ -90,5 +92,5 @@ steps:
 
 trigger:
   event:
-  include:
-  - tag
+    include:
+    - tag

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -122,12 +122,26 @@ catalogs/%/iGame.catalog: catalogs/%/iGame.ct catalogs/iGame.cd
 	flexcat catalogs/iGame.cd $< CATALOG $@ FILL QUIET || exit 0
 
 ##########################################################################
-# generic build options
+# build rules
 ##########################################################################
 
 %_$(CPU).o: %.c
 	@echo "Compiling $<"
 	@$(CC) -c $< -o $*_$(CPU).o $(CFLAGS) $(INCLUDES)
+
+src/funcs_$(CPU).o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h src/iGameExtern.h
+
+src/iGameGUI_$(CPU).o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h src/iGameExtern.h
+
+src/iGameMain_$(CPU).o: src/iGameMain.c src/iGameExtern.h
+
+src/strfuncs_$(CPU).o: src/strfuncs.c src/strfuncs.h
+
+src/fsfuncs_$(CPU).o: src/fsfuncs.c src/fsfuncs.h src/funcs.h src/iGameExtern.h
+
+##########################################################################
+# generic rules
+##########################################################################
 
 clean:
 	rm iGame iGame.* src/funcs*.o src/iGameGUI*.o src/iGameMain*.o src/strfuncs*.o src/iGame_cat*.o $(catalog_files)

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -2,7 +2,8 @@
 # Makefile for iGame on Docker VBCC images.
 #-------------------------------------------------------------------------
 # To compile an iGame flat executable  using this makefile, run:
-#  make -f Makefile.docker
+#  make -f Makefile.docker CPU=030
+#  CPU options are 000,030,040,060,MOS,OS4
 #-------------------------------------------------------------------------
 ##########################################################################
 
@@ -50,36 +51,66 @@ LINK		= vc
 CC_PPC		= vc
 LINK_PPC	= vc
 
-INCLUDES	= -I$(NDK_INC) -I$(MUI38_INC)
-INCLUDES_OS4= -I$(AOS4_SDK_INC) -I$(MUI50_INC)
-INCLUDES_MOS= -I$(NDK_INC) -I$(MUI38_INC)
-
-CFLAGS		= -c +aos68k -dontwarn=-1 -O2 -c99 -DCPU_VERS=68000 $(VERS_FLAGS)
-CFLAGS_030	= -c +aos68k -cpu=68030 -dontwarn=-1 -O2 -c99 -DCPU_VERS=68030 $(VERS_FLAGS)
-CFLAGS_040	= -c +aos68k -cpu=68040 -dontwarn=-1 -O2 -c99 -DCPU_VERS=68040 $(VERS_FLAGS)
-CFLAGS_060	= -c +aos68k -cpu=68060 -dontwarn=-1 -O2 -c99 -DCPU_VERS=68060 $(VERS_FLAGS)
-CFLAGS_MOS	= -c +morphos -dontwarn=-1 -O2 -DCPU_VERS=MorphOS $(VERS_FLAGS)
-CFLAGS_OS4	= -c +aosppc -dontwarn=-1 -O2 -D__USE_INLINE__ -DCPU_VERS=AmigaOS4 $(VERS_FLAGS)
+CPU ?= 000
 
 ##########################################################################
-# Builder settings
+# INCLUDES settings
 ##########################################################################
-#MKLIB			= join
-LIBFLAGS		= +aos68k -lamiga -o
-LIBFLAGS_MOS	= +morphos -lamiga -o
-LIBFLAGS_OS4	= +aosppc -lamiga -o
+
+ifneq (,$(filter 000 030 040 060,$(CPU)))
+INCLUDES += -I$(NDK_INC) -I$(MUI38_INC)
+endif
+ifneq (,$(filter OS4,$(CPU)))
+INCLUDES += -I$(AOS4_SDK_INC) -I$(MUI50_INC)
+endif
+ifneq (,$(filter MOS,$(CPU)))
+INCLUDES += -I$(NDK_INC) -I$(MUI38_INC)
+endif
+
+##########################################################################
+# CFLAGS settings
+##########################################################################
+
+CFLAGS = -c -dontwarn=-1 -O2 -c99 $(VERS_FLAGS)
+
+ifneq (,$(filter 000 030 040 060,$(CPU)))
+CFLAGS += +aos68k -DCPU_VERS=68$(CPU)
+endif
+ifneq (,$(filter OS4,$(CPU)))
+CFLAGS += +aosppc -D__USE_INLINE__ -DCPU_VERS=AmigaOS4
+endif
+ifneq (,$(filter MOS,$(CPU)))
+CFLAGS += +morphos -DCPU_VERS=MorphOS
+endif
+
+##########################################################################
+# Linker settings
+##########################################################################
+LIBFLAGS		= -lamiga
+
+ifneq (,$(filter 000 030 040 060,$(CPU)))
+LIBFLAGS += +aos68k -o
+endif
+ifneq (,$(filter OS4,$(CPU)))
+LIBFLAGS += +aosppc -o
+endif
+ifneq (,$(filter MOS,$(CPU)))
+LIBFLAGS += +morphos -o
+endif
 
 ##########################################################################
 # Object files which are part of iGame
 ##########################################################################
 
-include make_includes/obj_files.inc
+igame_OBJS	= src/funcs_$(CPU).o src/iGameGUI_$(CPU).o \
+	src/iGameMain_$(CPU).o src/strfuncs_$(CPU).o src/fsfuncs_$(CPU).o
 
 ##########################################################################
 # Rule for building
 ##########################################################################
 
-include make_includes/rules.inc
+iGame: $(igame_OBJS)
+	$(LINK) $(igame_OBJS) $(LIBFLAGS) $@.$(CPU)
 
 ##########################################################################
 # catalog files
@@ -91,44 +122,12 @@ catalogs/%/iGame.catalog: catalogs/%/iGame.ct catalogs/iGame.cd
 	flexcat catalogs/iGame.cd $< CATALOG $@ FILL QUIET || exit 0
 
 ##########################################################################
-# object files (generic 000)
-##########################################################################
-
-include make_includes/obj_000.inc
-
-##########################################################################
-# object files (030)
-##########################################################################
-
-include make_includes/obj_030.inc
-
-##########################################################################
-# object files (040)
-##########################################################################
-
-include make_includes/obj_040.inc
-
-##########################################################################
-# object files (060)
-##########################################################################
-
-include make_includes/obj_060.inc
-
-##########################################################################
-# object files (MOS)
-##########################################################################
-
-include make_includes/obj_mos.inc
-
-##########################################################################
-# object files (AOS4)
-##########################################################################
-
-include make_includes/obj_os4.inc
-
-##########################################################################
 # generic build options
 ##########################################################################
+
+%_$(CPU).o: %.c
+	@echo "Compiling $<"
+	@$(CC) -c $< -o $*_$(CPU).o $(CFLAGS) $(INCLUDES)
 
 clean:
 	rm iGame iGame.* src/funcs*.o src/iGameGUI*.o src/iGameMain*.o src/strfuncs*.o src/iGame_cat*.o $(catalog_files)
@@ -144,7 +143,7 @@ release: $(catalog_files)
 	cd iGame-$(DRONE_TAG) && mkdir $(catalog_dirs)
 	for c in $(catalog_files); do cp $$c iGame-$(DRONE_TAG)/$$(dirname $$c)/; done
 	cp CHANGELOG.md iGame-$(DRONE_TAG)/
-	if [ -f "iGame" ]; then cp iGame iGame-$(DRONE_TAG)/; fi
+	if [ -f "iGame.000" ]; then cp iGame.000 iGame-$(DRONE_TAG)/iGame; fi
 	if [ -f "iGame.030" ]; then cp iGame.030 iGame-$(DRONE_TAG)/; fi
 	if [ -f "iGame.040" ]; then cp iGame.040 iGame-$(DRONE_TAG)/; fi
 	if [ -f "iGame.060" ]; then cp iGame.060 iGame-$(DRONE_TAG)/; fi

--- a/make_includes/obj_000.inc
+++ b/make_includes/obj_000.inc
@@ -2,17 +2,17 @@
 # object files (generic 000)
 ##########################################################################
 
-src/funcs.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h
+src/funcs.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h src/iGameExtern.h
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h
+src/iGameGUI.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h src/iGameExtern.h
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameGUI.c
 
-src/iGameMain.o: src/iGameMain.c
+src/iGameMain.o: src/iGameMain.c src/iGameExtern.h
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/iGameMain.c
 
 src/strfuncs.o: src/strfuncs.c src/strfuncs.h
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/strfuncs.c
 
-src/fsfuncs.o: src/fsfuncs.c src/fsfuncs.h
+src/fsfuncs.o: src/fsfuncs.c src/fsfuncs.h src/funcs.h src/iGameExtern.h
 	$(CC) $(CFLAGS) $(INCLUDES) -o $@ src/fsfuncs.c

--- a/make_includes/obj_040.inc
+++ b/make_includes/obj_040.inc
@@ -2,17 +2,17 @@
 # object files (040)
 ##########################################################################
 
-src/funcs_040.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h
+src/funcs_040.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h src/iGameExtern.h
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h
+src/iGameGUI_040.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h src/iGameExtern.h
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameGUI.c
 
-src/iGameMain_040.o: src/iGameMain.c
+src/iGameMain_040.o: src/iGameMain.c src/iGameExtern.h
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/iGameMain.c
 
 src/strfuncs_040.o: src/strfuncs.c src/strfuncs.h
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/strfuncs.c
 
-src/fsfuncs_040.o: src/fsfuncs.c src/fsfuncs.h
+src/fsfuncs_040.o: src/fsfuncs.c src/fsfuncs.h src/funcs.h src/iGameExtern.h
 	$(CC) $(CFLAGS_040) $(INCLUDES) -o $@ src/fsfuncs.c

--- a/make_includes/obj_060.inc
+++ b/make_includes/obj_060.inc
@@ -2,17 +2,17 @@
 # object files (060)
 ##########################################################################
 
-src/funcs_060.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h
+src/funcs_060.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h src/iGameExtern.h
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/funcs.c
 
-src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h
+src/iGameGUI_060.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h src/iGameExtern.h
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameGUI.c
 
-src/iGameMain_060.o: src/iGameMain.c
+src/iGameMain_060.o: src/iGameMain.c src/iGameExtern.h
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/iGameMain.c
 
-src/strfuncs_060.o: src/strfuncs.c
+src/strfuncs_060.o: src/strfuncs.c src/strfuncs.h
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/strfuncs.c
 
-src/fsfuncs_060.o: src/fsfuncs.c src/fsfuncs.h
+src/fsfuncs_060.o: src/fsfuncs.c src/fsfuncs.h src/funcs.h src/iGameExtern.h
 	$(CC) $(CFLAGS_060) $(INCLUDES) -o $@ src/fsfuncs.c

--- a/make_includes/obj_mos.inc
+++ b/make_includes/obj_mos.inc
@@ -2,17 +2,17 @@
 # object files (MOS)
 ##########################################################################
 
-src/funcs_MOS.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h
+src/funcs_MOS.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h src/iGameExtern.h
 	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/funcs.c
 
-src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h
+src/iGameGUI_MOS.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h src/iGameExtern.h
 	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameGUI.c
 
-src/iGameMain_MOS.o: src/iGameMain.c
+src/iGameMain_MOS.o: src/iGameMain.c src/iGameExtern.h
 	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/iGameMain.c
 
 src/strfuncs_MOS.o: src/strfuncs.c src/strfuncs.h
 	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/strfuncs.c
 
-src/fsfuncs_MOS.o: src/fsfuncs.c src/fsfuncs.h
+src/fsfuncs_MOS.o: src/fsfuncs.c src/fsfuncs.h src/funcs.h src/iGameExtern.h
 	$(CC_PPC) $(CFLAGS_MOS) $(INCLUDES_MOS) -o $@ src/fsfuncs.c

--- a/make_includes/obj_os4.inc
+++ b/make_includes/obj_os4.inc
@@ -2,17 +2,17 @@
 # object files (AOS4)
 ##########################################################################
 
-src/funcs_OS4.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h
+src/funcs_OS4.o: src/funcs.c src/iGame_strings.h src/strfuncs.h src/fsfuncs.h src/iGameExtern.h
 	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/funcs.c
 
-src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h
+src/iGameGUI_OS4.o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h src/fsfuncs.h src/iGameExtern.h
 	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameGUI.c
 
-src/iGameMain_OS4.o: src/iGameMain.c
+src/iGameMain_OS4.o: src/iGameMain.c src/iGameExtern.h
 	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/iGameMain.c
 
 src/strfuncs_OS4.o: src/strfuncs.c src/strfuncs.h
 	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/strfuncs.c
 
-src/fsfuncs_OS4.o: src/fsfuncs.c src/fsfuncs.h
+src/fsfuncs_OS4.o: src/fsfuncs.c src/fsfuncs.h src/funcs.h src/iGameExtern.h
 	$(CC_PPC) $(CFLAGS_OS4) $(INCLUDES_OS4) -o $@ src/fsfuncs.c


### PR DESCRIPTION
Enhanced the makefile for docker, removing duplicated code and and making more flexible. Now this makefile doesn't use the include files under "make_includes" folder, except the one for the catalogs. Those files remain there though so that can be used by the rest of Makefiles.

Now, in the Makefile.docker, there is only one rule for building iGame and the CPU is set by default to 000, which is for 68000. If the user wants to compile a different version the CPU argument needs to be provided, i.e
```
make -f Makefile.docker CPU=030
make -f Makefile.docker CPU=OS4
```