### PR TITLE
Fixed 68K cpu specific versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
+### Fixed
+- Now the 68K cpu specific versions are included in the archive. In v2.2.0 all versions where the same 68000 binary because of a missing flag in compilation
+
+## iGame 2.2.0 - [2022-11-06]
 ### Added
 - Added automatic release to Aminet and OS4Depot through the CI/CD whenever a new release tag is created at the repo
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -67,7 +67,7 @@ endif
 CFLAGS = -c -dontwarn=-1 -O2 -c99 $(VERS_FLAGS)
 
 ifneq (,$(filter 000 030 040 060,$(CPU)))
-CFLAGS += +aos68k -DCPU_VERS=68$(CPU)
+CFLAGS += +aos68k -cpu=68$(CPU) -DCPU_VERS=68$(CPU)
 endif
 ifneq (,$(filter OS4,$(CPU)))
 CFLAGS += +aosppc -D__USE_INLINE__ -DCPU_VERS=AmigaOS4


### PR DESCRIPTION
With the previous changes of v2.2.0 there was a missing flag in compilation