### PR TITLE
Screenshot enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ### Fixed
 - The custom screenshot sizes were wrongly saved. This is now fixed (#190)
 
+### Changed
+- Added some spaces left and right of the screenshot. This helps to resize the sidebar as needed keeping the screenshot centred
+- Now, only the screenshot part of the GUI is updated on item selection and not the whole right side. This makes the GUI refresh faster on slow computers
+- If the screenshot is toggled (show/hide) in the settings window the GUI is updated without the need of restarting iGame
+- Now iGame doesn't fail to start even if any of the guigfx.library, render.library or Guigfx.mcc is missing. It falls back using the datatypes and the "No GuiGfx" checkbox is blocked in the settings
+
 ## iGame 2.3.1 - [2023-04-14]
 ### Fixed
 - This is a hot fix release for the installer script that had a bug of not finding the icons folder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
 ### Fixed
+- The custom screenshot sizes were wrongly saved. This is now fixed (#190)
+
+## iGame 2.3.1 - [2023-04-14]
+### Fixed
 - This is a hot fix release for the installer script that had a bug of not finding the icons folder
 
 ## iGame 2.3.0 - [2023-04-13]

--- a/required_files/iGame.guide
+++ b/required_files/iGame.guide
@@ -293,11 +293,11 @@ If you have different instances of iGame and you would like to keep the same pre
 The settings window has three separate sections:
 
 @{u}Screenshots@{uu}
-The first checkbox here, named "Hide Screenshots", disables the screenshot part of the main window. This change requires to restart iGame to be applied.
+The first checkbox here, named "Hide Screenshots", disables the screenshot part of the main window. iGame window will be refreshed to show/hide the screenshot as soon as you apply the changes.
 
-If screenshots are enabled you can select from the second checkbox if the GuiGfx library will be used. GuiGfx provides good scaling of the screenshot but it is a little bit tricky to set this up. You can find more info at @{" Installation " LINK "INST" 0} section. If this is checked iGame will not use the GuiGfx library.
+If screenshots are enabled you can select from the second checkbox if the GuiGfx library will be used. GuiGfx provides good scaling of the screenshot but it is a little bit tricky to set this up. You can find more info at @{" Installation " LINK "INST" 0} section. If this checkbox is selected that means that iGame will not use the GuiGfx library. If the library is not installed or the prerequisites are missing, then iGame will use datatypes to show the screenshot and this checkbox will be disabled.
 
-After that, there is a select box to choose the screenshot size. You can choose between 160x128 pixels, 320x256 pixels and custom, which lets you set the width and height manually, using the fields below the select box.
+Under that, there is a select box to choose the screenshot size. You can choose between 160x128 pixels, 320x256 pixels and custom, which lets you set the width and height manually, using the fields below the select box.
 
 @{u}Titles@{uu}
 The first two radio buttons set the way iGame gets the WHDLoad games/demos titles. These can be based on reading the slave files or by the game/demo parent folder name. If you choose the "Slave Contents" option the name can be more accurate, but the scanning is slower. The "Directories" option is way faster, but if the slave inside a folder is not the one the directory is named, then there is a risk to have the wrong game in the list. Have in mind that if iGame finds multiple slaves for the same game, their titles will be suffixed with the 'Alt' word.

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1315,11 +1315,6 @@ static LONG xget(Object* obj, ULONG attribute)
 	return x;
 }
 
-char* get_str(Object* obj)
-{
-	return (char *)xget(obj, MUIA_String_Contents);
-}
-
 static int get_cycle_index(Object* obj)
 {
 	int index = 0;
@@ -1414,8 +1409,14 @@ void settings_use(void)
 	const int index = get_cycle_index(app->CY_ScreenshotSize);
 	if (index == 2)
 	{
-		current_settings->screenshot_width = (int)get_str(app->STR_Width);
-		current_settings->screenshot_height = (int)get_str(app->STR_Height);
+		char *width = NULL;
+		char *height = NULL;
+
+		get(app->STR_Width, MUIA_String_Contents, &width);
+		get(app->STR_Height, MUIA_String_Contents, &height);
+
+		current_settings->screenshot_width = atoi(width);
+		current_settings->screenshot_height = atoi(height);
 	}
 
 	set(app->WI_Settings, MUIA_Window_Open, FALSE);

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -67,6 +67,7 @@
 #include "iGameGUI.h"
 
 extern igame_settings *current_settings;
+extern blockGuiGfx;
 
 static void translateMenu(struct NewMenu *);
 static void flagMenuItem(struct NewMenu *, APTR, UWORD);
@@ -317,6 +318,7 @@ struct ObjApp *CreateApp(void)
 		MUIA_Listview_MultiSelect, MUIV_Listview_MultiSelect_None,
 		MUIA_Listview_DoubleClick, TRUE,
 		MUIA_Listview_List, object->LV_GamesList,
+		MUIA_Weight, 200,
 		End;
 
 	if (!current_settings->hide_side_panel)
@@ -339,27 +341,33 @@ struct ObjApp *CreateApp(void)
 					MUIA_FixWidth, current_settings->screenshot_width,
 				End;
 			}
+
+			object->GR_spacedScreenshot = HGroup, MUIA_Group_Spacing, 0,
+				Child, HSpace(0),
+				Child, object->IM_GameImage_0,
+				Child, HSpace(0),
+				End;
 		}
 
 		object->Space_Sidepanel = VSpace(1);
 
 		object->LV_GenresList = ListObject,
 			MUIA_Frame, MUIV_Frame_InputList,
-		        MUIA_List_Active, MUIV_List_Active_Top,
+			MUIA_List_Active, MUIV_List_Active_Top,
 			End;
 
 		object->LV_GenresList = ListviewObject,
 			MUIA_HelpNode, "LV_GenresList",
 			MUIA_FrameTitle, GetMBString(MSG_LV_GenresListTitle),
 			MUIA_Listview_List, object->LV_GenresList,
-			MUIA_MaxWidth, current_settings->screenshot_width,	//keep the same width as if there was a screenshot area
 			End;
 
 		if (!current_settings->hide_screenshots) {
 
 			object->GR_sidepanel = GroupObject,
 				MUIA_HelpNode, "GR_sidepanel",
-				Child, object->IM_GameImage_0,
+				MUIA_Weight, 100,
+				Child, object->GR_spacedScreenshot,
 				Child, object->Space_Sidepanel,
 				Child, object->LV_GenresList,
 				End;
@@ -368,6 +376,7 @@ struct ObjApp *CreateApp(void)
 
 			object->GR_sidepanel = GroupObject,
 				MUIA_HelpNode, "GR_sidepanel",
+				MUIA_Weight, 100,
 				Child, object->Space_Sidepanel,
 				Child, object->LV_GenresList,
 				End;
@@ -376,7 +385,7 @@ struct ObjApp *CreateApp(void)
 		GR_main = GroupObject,
 			MUIA_HelpNode, "GR_main",
 			MUIA_Group_Horiz, TRUE,
-			Child, object->LV_GamesList, MUIA_Weight, 60,
+			Child, object->LV_GamesList,
 			Child, BalanceObject,
 				MUIA_CycleChain, 1,
 				MUIA_ObjectID, MAKE_ID('B', 'A', 'L', 0),
@@ -767,6 +776,10 @@ struct ObjApp *CreateApp(void)
 	LA_HideScreenshots = Label(GetMBString(MSG_LA_HideScreenshots));
 
 	object->CH_NoGuiGfx = CheckMark(FALSE);
+	if (blockGuiGfx)
+	{
+		set(object->CH_NoGuiGfx, MUIA_Disabled, TRUE);
+	}
 
 	LA_NoGuiGfx = Label(GetMBString(MSG_LA_NoGuiGfx));
 

--- a/src/iGameGUI.h
+++ b/src/iGameGUI.h
@@ -36,6 +36,7 @@ struct ObjApp
 	APTR MN_MainMenu;
 	APTR STR_Filter;
 	APTR GR_sidepanel;
+	APTR GR_spacedScreenshot;
 	APTR IM_GameImage_0;
 	APTR IM_GameImage_1;
 	APTR Space_Sidepanel;

--- a/src/iGameMain.c
+++ b/src/iGameMain.c
@@ -89,6 +89,7 @@ struct Library			*WorkbenchBase;
 char *executable_name;   // TODO: Why global?
 
 igame_settings* iGameSettings = NULL;
+BOOL blockGuiGfx = FALSE;
 
 static int initLibraries(void);
 static void cleanupLibraries(void);
@@ -329,26 +330,13 @@ static int initLibraries(void)
 	// Load settings here, after we load the icon.library
 	iGameSettings = load_settings(DEFAULT_SETTINGS_FILE);
 
-	if (!iGameSettings->hide_screenshots && !iGameSettings->hide_side_panel)
-	{
-		if (!(RenderLibBase = OpenLibrary("render.library", 30)))
-		{
-			return clean_exit("Can't open render.library v30 or greater\n");
-		}
-
-		if (!iGameSettings->no_guigfx)
-		{
-
-			if (!(GuiGfxBase = OpenLibrary("guigfx.library", 17)))
-			{
-				return clean_exit("Can't open guigfx.library v17 or greater\n");
-			}
-
-			if (!(GuiGfxMCC = OpenLibrary("mui/Guigfx.mcc", 19)))
-			{
-				return clean_exit("Can't open Guigfx.mcc v19 or greater\n");
-			}
-		}
+	if (
+		!(RenderLibBase = OpenLibrary("render.library", 30)) ||
+		!(GuiGfxBase = OpenLibrary("guigfx.library", 17)) ||
+		!(GuiGfxMCC = OpenLibrary("mui/Guigfx.mcc", 19))
+	) {
+		iGameSettings->no_guigfx = 1;
+		blockGuiGfx = TRUE;
 	}
 
 	return RETURN_OK;


### PR DESCRIPTION
### Fixed
- The custom screenshot sizes were wrongly saved. This is now fixed (#190)

### Changed
- Added some spaces left and right of the screenshot. This helps to resize the sidebar as needed keeping the screenshot centred
- Now, only the screenshot part of the GUI is updated on item selection and not the whole right side. This makes the GUI refresh faster on slow computers
- If the screenshot is toggled (show/hide) in the settings window the GUI is updated without the need of restarting iGame
- Now iGame doesn't fail to start even if any of the guigfx.library, render.library or Guigfx.mcc is missing. It falls back using the datatypes and the "No GuiGfx" checkbox is blocked in the settings
