### PR TITLE
Fixed repo removal from the repos list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
 ### Fixed
+- Fixed a bug on repo removal, which remained in the repos list and was included in scans, unless the user restarted iGame
+
+ ## iGame 2.3.2 - [2023-04-20]
+### Fixed
 - The custom screenshot sizes were wrongly saved. This is now fixed (#190)
 - Fixed a duplication in slave names after the execution of a second scan in the same list, introduced in v2.3.0
 - Fixed a crash on systems that use AutoUpdateWB patch. **HUGE THANKS to mfilos** for his testing, feedback and support up to late at nights

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1054,8 +1054,28 @@ void repo_add(void)
 
 void repo_remove(void)
 {
-	// TODO: If a repo is removed is not removed from the list
-	DoMethod(app->LV_GameRepositories, MUIM_List_Remove, MUIV_List_Remove_Active);
+	char *path = NULL;
+	DoMethod(app->LV_GameRepositories, MUIM_List_GetEntry, MUIV_List_GetEntry_Active, &path);
+
+	repos_list *prevRepo = NULL;
+	for (item_repos = repos; item_repos != NULL; item_repos = item_repos->next)
+	{
+		if (!strcmp(path, item_repos->repo))
+		{
+			if (prevRepo->repo)
+			{
+				prevRepo->next = item_repos->next;
+			}
+			else
+			{
+				repos = item_repos->next;
+			}
+			free(item_repos);
+			DoMethod(app->LV_GameRepositories, MUIM_List_Remove, MUIV_List_Remove_Active);
+			return;
+		}
+		prevRepo = item_repos;
+	}
 }
 
 /*


### PR DESCRIPTION
Fixed a bug on repo removal, which remained in the repos list and was included in scans, unless the user restarted iGame