### PR TITLE
Added genres from igame.data files and a fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
 ### Added
+- Now the Genre list is populated from the igame.data files and the genre file, if it exists, although it is not necessary. The genre filtering is working with these new values
+
+### Fixed
+- Fixed a hit when the entry properties are requested without having a selected entry
+
+## iGame 2.4.0 - [2023-05-13]
+### Added
 - Added back the saving of the list after a scan of the repositories, which was removed in the previous releases
 - Introduced the new igame.data files
 - iGame uses NList now with extra columns that are sortable

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -66,7 +66,7 @@ endif
 # CFLAGS settings
 ##########################################################################
 
-CFLAGS = -c -dontwarn=-1 -O2 -c99 $(VERS_FLAGS)
+CFLAGS = -c -dontwarn=-1 -O2 -c99 $(VERS_FLAGS) -g -hunkdebug
 
 ifneq (,$(filter 000 030 040 060,$(CPU)))
 CFLAGS += +aos68k -cpu=68$(CPU) -DCPU_VERS=68$(CPU)
@@ -81,7 +81,7 @@ endif
 ##########################################################################
 # Linker settings
 ##########################################################################
-LIBFLAGS		= -lamiga
+LIBFLAGS = -lamiga -g -Bamigahunk
 
 ifneq (,$(filter 000 030 040 060,$(CPU)))
 LIBFLAGS += +aos68k -o
@@ -99,7 +99,7 @@ endif
 
 igame_OBJS	= src/funcs_$(CPU).o src/iGameGUI_$(CPU).o \
 	src/iGameMain_$(CPU).o src/strfuncs_$(CPU).o src/fsfuncs_$(CPU).o \
-	src/slavesList_$(CPU).o
+	src/slavesList_$(CPU).o src/genresList_$(CPU).o
 
 ##########################################################################
 # Rule for building
@@ -127,7 +127,7 @@ catalogs/%/iGame.catalog: catalogs/%/iGame.ct catalogs/iGame.cd
 	@$(CC) -c $< -o $*_$(CPU).o $(CFLAGS) $(INCLUDES)
 
 src/funcs_$(CPU).o: src/funcs.c src/iGame_strings.h src/strfuncs.h \
-	src/fsfuncs.h src/iGameExtern.h src/slavesList.h
+	src/fsfuncs.h src/iGameExtern.h src/slavesList.h src/genresList.h
 
 src/iGameGUI_$(CPU).o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h \
 	src/fsfuncs.h src/iGameExtern.h
@@ -137,9 +137,11 @@ src/iGameMain_$(CPU).o: src/iGameMain.c src/iGameExtern.h
 src/strfuncs_$(CPU).o: src/strfuncs.c src/iGameExtern.h src/strfuncs.h
 
 src/fsfuncs_$(CPU).o: src/fsfuncs.c src/fsfuncs.h src/funcs.h \
-	src/iGameExtern.h src/slavesList.h
+	src/iGameExtern.h src/slavesList.h src/genresList.h
 
 src/slavesList_$(CPU).o: src/slavesList.c src/slavesList.h
+
+src/genresList_$(CPU).o: src/genresList.c src/genresList.h
 
 ##########################################################################
 # generic rules

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -66,7 +66,7 @@ endif
 # CFLAGS settings
 ##########################################################################
 
-CFLAGS = -c -dontwarn=-1 -O2 -c99 $(VERS_FLAGS) -g -hunkdebug
+CFLAGS = -c -dontwarn=-1 -O2 -c99 $(VERS_FLAGS)
 
 ifneq (,$(filter 000 030 040 060,$(CPU)))
 CFLAGS += +aos68k -cpu=68$(CPU) -DCPU_VERS=68$(CPU)
@@ -81,7 +81,7 @@ endif
 ##########################################################################
 # Linker settings
 ##########################################################################
-LIBFLAGS = -lamiga -g -Bamigahunk
+LIBFLAGS = -lamiga
 
 ifneq (,$(filter 000 030 040 060,$(CPU)))
 LIBFLAGS += +aos68k -o

--- a/required_files/iGame.guide
+++ b/required_files/iGame.guide
@@ -370,7 +370,7 @@ and of course, all of you who use iGame and support our beloved Amiga computer.
 @{lindent 3}
 @{b}Introducing igame.data files@{ub}
 
-iGame scans for a nd if found uses a custom file with the filename igame.data. These files let iGame know some crucial information for each entry (game/demo/application). Those files have a very specific structure and should be in the same folder of the WHDLoad items where the slave file exists, or in the same folder where an executable file exists.
+iGame scans for and if found uses a custom file with the filename igame.data. These files let iGame know some crucial information for each entry (game/demo/application). Those files have a very specific structure and should be in the same folder of the WHDLoad items where the slave file exists, or in the same folder where an executable file exists.
 
 igame.data information is meant to cover (non)WHDLoad items and Demos, including as much information as possible. Not all the information is going to be loaded in the memory, just those that are necessary for some features in iGame. Other information will be used only when the user requests to view it.
 

--- a/src/fsfuncs.c
+++ b/src/fsfuncs.c
@@ -54,6 +54,7 @@
 #include "iGameExtern.h"
 #include "strfuncs.h"
 #include "slavesList.h"
+#include "genresList.h"
 #include "funcs.h"
 #include "fsfuncs.h"
 
@@ -203,39 +204,31 @@ void slavesListLoadFromCSV(char *filename)
 
 				buf = strtok(NULL, ";");
 				node->title[0] = '\0';
+				sprintf(node->title, "%s", buf);
 				if (strcasestr(buf, "\""))
 				{
 					sprintf(node->title,"%s", substring(buf, 1, -2));
 				}
-				else
-				{
-					sprintf(node->title,"%s", buf);
-				}
 
 				buf = strtok(NULL, ";");
 				node->genre[0] = '\0';
+				sprintf(node->genre, "%s", buf);
 				if (strcasestr(buf, "\""))
 				{
 					sprintf(node->genre,"%s", substring(buf, 1, -2));
-				}
-				else
-				{
-					sprintf(node->genre,"%s", buf);
 				}
 				if(isStringEmpty(node->genre))
 				{
 					sprintf(node->genre,"Unknown");
 				}
+				addGenreInList(node->genre);
 
 				buf = strtok(NULL, ";");
 				node->path[0] = '\0';
+				sprintf(node->path, "%s", buf);
 				if (strcasestr(buf, "\""))
 				{
-					sprintf(node->path,"%s", substring(buf, 1, -2));
-				}
-				else
-				{
-					sprintf(node->path,"%s", buf);
+					sprintf(node->path, "%s", substring(buf, 1, -2));
 				}
 
 				buf = strtok(NULL, ";");
@@ -257,13 +250,10 @@ void slavesListLoadFromCSV(char *filename)
 				node->user_title[0] = '\0';
 				if (buf)
 				{
+					sprintf(node->user_title, "%s", buf);
 					if (strcasestr(buf, "\""))
 					{
-						sprintf(node->user_title,"%s", substring(buf, 1, -2));
-					}
-					else
-					{
-						sprintf(node->user_title,"%s", buf);
+						sprintf(node->user_title, "%s", substring(buf, 1, -2));
 					}
 				}
 
@@ -704,5 +694,26 @@ void getIGameDataInfo(char *igameDataPath, slavesList *node)
 
 		free(line);
 		Close(fpigamedata);
+	}
+}
+
+void loadGenresFromFile(void)
+{
+	const BPTR fpgenres = Open(DEFAULT_GENRES_FILE, MODE_OLDFILE);
+	if (fpgenres)
+	{
+		int lineSize = MAX_GENRE_NAME_SIZE;
+		char *line = malloc(lineSize * sizeof(char));
+		while (FGets(fpgenres, line, lineSize) != NULL)
+		{
+			line[strlen(line) - 1] = '\0';
+			if (!isStringEmpty(line))
+			{
+				addGenreInList(line);
+			}
+		}
+
+		free(line);
+		Close(fpgenres);
 	}
 }

--- a/src/fsfuncs.h
+++ b/src/fsfuncs.h
@@ -42,5 +42,6 @@ void setIconTooltypes(char *, char *);
 BOOL checkSlaveInTooltypes(char *, char *);
 void prepareWHDExecution(char *, char *);
 void getIGameDataInfo(char *, slavesList *);
+void loadGenresFromFile(void);
 
 #endif

--- a/src/genresList.c
+++ b/src/genresList.c
@@ -1,0 +1,142 @@
+/*
+  genresList.c
+  genres list functions source for iGame
+
+  Copyright (c) 2018-2023, Emmanuel Vasilakis
+
+  This file is part of iGame.
+
+  iGame is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  iGame is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with iGame. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <exec/types.h>
+
+#include "iGameExtern.h"
+#include "genresList.h"
+
+genresList *genresListHead = NULL;
+
+static int isListEmpty(const void *head)
+{
+	return head == NULL;
+}
+
+void genresListAddTail(genresList *node)
+{
+	if (node != NULL)
+	{
+		node->next = NULL;
+
+		if (isListEmpty(genresListHead))
+		{
+			genresListHead = node;
+		}
+		else
+		{
+			// find the last node
+			genresList *currPtr = genresListHead;
+			while (currPtr->next != NULL)
+			{
+				currPtr = currPtr->next;
+			}
+
+			currPtr->next = node;
+		}
+	}
+}
+
+static BOOL genresListRemoveHead(void) {
+
+	if (isListEmpty(genresListHead)) {
+		return FALSE;
+	}
+
+	genresList *nextPtr = genresListHead->next;
+	free(genresListHead);
+	genresListHead = nextPtr;
+	return TRUE;
+}
+
+void genresListPrint(void)
+{
+	int cnt = 0;
+	genresList *currPtr = genresListHead;
+	while (currPtr != NULL)
+	{
+		printf("----> %s\n", currPtr->title);
+		currPtr = currPtr->next;
+		cnt++;
+	}
+	printf("END OF LIST: %d items\n", cnt);
+}
+
+genresList *genresListSearchByTitle(char *title, unsigned int titleSize)
+{
+	if (isListEmpty(genresListHead))
+	{
+		return NULL;
+	}
+
+	genresList *currPtr = genresListHead;
+	while (
+		currPtr != NULL &&
+		strncmp(currPtr->title, title, titleSize)
+	) {
+		currPtr = currPtr->next;
+	}
+
+	return currPtr;
+}
+
+genresList *getGenresListHead(void)
+{
+	return genresListHead;
+}
+
+void emptyGenresList(void)
+{
+	while(genresListRemoveHead())
+	{}
+}
+
+int genresListNodeCount(int cnt)
+{
+	static int nodeCount = 0;
+
+	if (cnt == -1)
+	{
+		return nodeCount;
+	}
+
+	nodeCount = cnt;
+	return nodeCount;
+}
+
+void addGenreInList(char *title)
+{
+	if (genresListSearchByTitle(title, sizeof(char) * MAX_GENRE_NAME_SIZE) == NULL)
+	{
+		genresList *node = malloc(sizeof(genresList));
+		if(node == NULL)
+		{
+			return;
+		}
+		strncpy(node->title, title, sizeof(char) * MAX_GENRE_NAME_SIZE);
+		genresListAddTail(node);
+	}
+}

--- a/src/genresList.h
+++ b/src/genresList.h
@@ -1,0 +1,34 @@
+/*
+  genresList.h
+  genres list functions header for iGame
+
+  Copyright (c) 2018-2023, Emmanuel Vasilakis
+
+  This file is part of iGame.
+
+  iGame is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  iGame is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with iGame. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _GENRES_LIST_H
+#define _GENRES_LIST_H
+
+void genresListAddTail(genresList *);
+void genresListPrint(void);
+genresList *genresListSearchByTitle(char *, unsigned int);
+genresList *getGenresListHead(void);
+void emptyGenresList(void);
+int genresListNodeCount(int);
+void addGenreInList(char *);
+
+#endif

--- a/src/iGameExtern.h
+++ b/src/iGameExtern.h
@@ -85,11 +85,11 @@ typedef struct settings
 	int useIgameDataTitle;
 } igame_settings;
 
-typedef struct genres
+typedef struct genresList
 {
-	char genre[256];
-	struct genres* next;
-} genres_list;
+	char title[MAX_GENRE_NAME_SIZE];
+	struct genresList *next;
+} genresList;
 
 typedef struct repos
 {


### PR DESCRIPTION
### Added
- Now the Genre list is populated from the igame.data files and the genre file, if it exists, although it is not necessary. The genre filtering is working with these new values

### Fixed
- Fixed a hit when the entry properties are requested without having a selected entry