### PR TITLE
Realtime filtering is enabled at least 3 characters are required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
+### Changed
+- When realtime filtering is enabled at least 3 characters are required so as to be initiated. Less than 3 characters are ignored, unless the filtering by pressing the enter button is enabled.
+
+## iGame 2.4.0 - [2023-05-13]
 ### Added
 - Added back the saving of the list after a scan of the repositories, which was removed in the previous releases
 - Introduced the new igame.data files

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -400,6 +400,10 @@ void filter_change(void)
 	filters.showGenre[0] = '\0';
 
 	get(app->STR_Filter, MUIA_String_Contents, &title);
+	if (!current_settings->filter_use_enter && strlen(title) > 0 && strlen(title) < MIN_TITLE_FILTER_CHARS) {
+		return;
+	}
+
 	DoMethod(app->LV_GenresList, MUIM_List_GetEntry,
 		MUIV_List_GetEntry_Active, &genreSelection);
 

--- a/src/iGameExtern.h
+++ b/src/iGameExtern.h
@@ -69,6 +69,7 @@
 #define MAX_EXEC_SIZE 256
 #define MAX_TOOLTYPE_SIZE 64
 #define MAX_ARGUMENTS_SIZE 64
+#define MIN_TITLE_FILTER_CHARS 3
 
 typedef struct settings
 {

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -1308,7 +1308,7 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 
 		DoMethod(object->STR_Filter,
 			MUIM_Notify, MUIA_String_Contents, MUIV_EveryTime,
-		object->App,
+			object->App,
 			2,
 			MUIM_CallHook, &FilterChangeHook
 		);


### PR DESCRIPTION
 - When realtime filtering is enabled at least 3 characters are required so as to be initiated. Less than 3 characters are ignored, unless the filtering by pressing the enter button is enabled.