### PR TITLE
Added a new filter cycle box above entries list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
-### Changed
-- When realtime filtering is enabled at least 3 characters are required so as to be initiated. Less than 3 characters are ignored, unless the filtering by pressing the enter button is enabled.
-
-## iGame 2.4.0 - [2023-05-13]
 ### Added
 - Now the Genre list is populated from the igame.data files and the genre file, if it exists, although it is not necessary. The genre filtering is working with these new values
+
+### Changed
+- When realtime filtering is enabled at least 3 characters are required so as to be initiated. Less than 3 characters are ignored, unless the filtering by pressing the enter button is enabled.
+- Removed the filtering options from the Genre list and moved to its own select box above entries list
 
 ### Fixed
 - Fixed a hit when the entry properties are requested without having a selected entry

--- a/required_files/iGame.guide
+++ b/required_files/iGame.guide
@@ -17,7 +17,7 @@ iGame
 
 @{" Installation    " LINK "INST" 0} - How to install iGame
 @{" Usage           " LINK "USAG" 0} - Using iGame
-@{" igame.data      " LINK "IGDF" 0} - About igame.data files
+@{" igame.data file " LINK "IGDF" 0} - About igame.data files
 
 @{" Todo & Bugs     " LINK "TODO" 0} - Todo and known bugs
 @{" Author          " LINK "INFO" 0} - Author contact info
@@ -239,13 +239,15 @@ This menu opens the MUI Settings window, where you can change the look of MUI co
 @{lindent 3}
 The Main Window is what you see when you start iGame. It is pretty simple to use and it has only a few fields.
 
-At the top, there is the "Filter" field which is used to filter the list of entries, based on your input. iGame returns entries with a matching part in their title. For example, if you want to find all the games that have "Soccer" in their title, that's what you need to write. The search is not case-sensitive, so it doesn't matter if the part of the title is capitalized or not. From the iGame settings, you can set it when the search is initialized, while you type or after you press "Enter".
+At the top, there is the "Filter" field which is used to filter the list of entries, based on your input. iGame returns entries with a matching part in their title. For example, if you want to find all the games that have "Soccer" in their title, that's what you need to write. The search is not case-sensitive, so it doesn't matter if the part of the title is capitalized or not. From the iGame settings, you can set it when the search is initialized, while you type (3 minimum characters) or after you press "Enter".
 
-On the left side, there is the list, where all the entries (games, demos etc.) are shown. With a double click on an entry, it is executed. If you want to add some information on an entry using the "Game > Properties..." menu, that's the list where you have to select it first.
+On the left side, there are a filter select box and the entries list. The filter select box helps tp filter the entries by "Last played", "Favorites", "Most Played" and "Never Played".
 
-At the top right side, there is a screenshot of the selected entry. For the screenshot, iGame uses an image file, which must be in the same folder as the game/demo, named @{b}igame.iff@{ub}. If no screenshot is available then the game icon is shown. You can disable the screenshots from the @{" Settings Window " LINK "WINSETS" 0}.
+The entries list holds the entries (games, demos etc.) based on the filtering. With a double click on an entry, it is executed. If you want to add some information on an entry using the "Game > Properties..." menu, that's the list where you have to select it first. The list has 3 columns, where the first one has the title, the second one shows the year of release and the third column shows the maximum number of players that can play. iGame uses @{" igame.data files " LINK "IGDF" 0} to gather that information. By clicking on their title the sorting of the list can change.
 
-Under the screenshot, there is the "Genres" list which helps you filter the games based on the "Genre", as well as by "Last played", "Favorites", "Most Played" and "Never Played". There is also an "Unknown" selection which shows the entries that do not have any Genre assigned.
+At the top right side, there is a screenshot of the selected entry. For the screenshot, iGame uses an image file, which must be in the same folder as the game/demo, named @{b}igame.iff@{ub}. If no screenshot is available then the entry icon is shown. You can disable the screenshots from the @{" Settings Window " LINK "WINSETS" 0}.
+
+Under the screenshot, there is the "Genres" list which helps you filter the games based on the "Genre". There is also an "Unknown" selection which shows the entries that do not have any Genre assigned.
 
 At the bottom, there is a read-only field which shows information about iGame, based on what you are doing. It is like a status bar, where useful information will be shown while you use iGame.
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -68,7 +68,7 @@ char fname[255];
 BOOL sidepanelChanged = FALSE; // This is temporary until settings are revamped
 
 /* function definitions */
-static void add_default_filters(void);
+static int get_cycle_index(Object *);
 static void showSlavesList(void);
 static LONG xget(Object *, ULONG);
 
@@ -290,7 +290,8 @@ static void populateGenresList(void)
 	DoMethod(app->LV_GenresList, MUIM_List_Clear);
 	set(app->LV_GenresList, MUIA_List_Quiet, TRUE);
 
-	add_default_filters();
+	// Add Show All in genres list
+	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterShowAll), MUIV_List_Insert_Bottom);
 	loadGenresFromFile();
 	addGenreInList(GetMBString(MSG_UnknownGenre));
 
@@ -315,15 +316,6 @@ static void populateGenresList(void)
 	set(app->CY_PropertiesGenre, MUIA_Cycle_Entries, app->CY_PropertiesGenreContent);
 	set(app->CY_AddGameGenre, MUIA_Cycle_Entries, app->CY_PropertiesGenreContent);
 	set(app->LV_GenresList, MUIA_List_Quiet, FALSE);
-}
-
-static void add_default_filters(void)
-{
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterShowAll), MUIV_List_Insert_Bottom);
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterFavorites), MUIV_List_Insert_Bottom);
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterLastPlayed), MUIV_List_Insert_Bottom);
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterMostPlayed), MUIV_List_Insert_Bottom);
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterNeverPlayed), MUIV_List_Insert_Bottom);
 }
 
 // Clears the list of items
@@ -372,6 +364,7 @@ void filter_change(void)
 	char *title = NULL;
 	char *genreSelection = NULL;
 	filters.showGenre[0] = '\0';
+	filters.showGroup = get_cycle_index(app->CY_FilterList);
 
 	get(app->STR_Filter, MUIA_String_Contents, &title);
 	if (!current_settings->filter_use_enter && strlen(title) > 0 && strlen(title) < MIN_TITLE_FILTER_CHARS) {
@@ -388,22 +381,11 @@ void filter_change(void)
 	}
 	else filters.title[0] = '\0';
 
+	if (!isStringEmpty(genreSelection))
+		strncpy(filters.showGenre, genreSelection, sizeof(filters.showGenre));
+
 	if (genreSelection == NULL || !strcmp(genreSelection, GetMBString(MSG_FilterShowAll)))
-		filters.showGroup = GROUP_SHOWALL;
-
-	else if (!strcmp(genreSelection, GetMBString(MSG_FilterFavorites)))
-		filters.showGroup = GROUP_FAVOURITES;
-
-	else if (!strcmp(genreSelection, GetMBString(MSG_FilterLastPlayed)))
-		filters.showGroup = GROUP_LAST_PLAYED;
-
-	else if (!strcmp(genreSelection, GetMBString(MSG_FilterMostPlayed)))
-		filters.showGroup = GROUP_MOST_PLAYED;
-
-	else if (!strcmp(genreSelection, GetMBString(MSG_FilterNeverPlayed)))
-		filters.showGroup = GROUP_NEVER_PLAYED;
-
-	else strncpy(filters.showGenre, genreSelection, sizeof(filters.showGenre));
+		filters.showGenre[0] = '\0';
 
 	showSlavesList();
 }

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -421,13 +421,22 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 
 	object->CY_PropertiesGenreContent[0] = (CONST_STRPTR)GetMBString(MSG_CY_PropertiesGenre0);
 	object->CY_PropertiesGenreContent[1] = NULL;
+
 	object->CY_ScreenshotSizeContent[0] = (CONST_STRPTR)GetMBString(MSG_CY_ScreenshotSize0);
 	object->CY_ScreenshotSizeContent[1] = (CONST_STRPTR)GetMBString(MSG_CY_ScreenshotSize1);
 	object->CY_ScreenshotSizeContent[2] = (CONST_STRPTR)GetMBString(MSG_CY_ScreenshotSize2);
 	object->CY_ScreenshotSizeContent[3] = NULL;
+
 	object->RA_TitlesFromContent[0] = (CONST_STRPTR)GetMBString(MSG_RA_TitlesFrom0);
 	object->RA_TitlesFromContent[1] = (CONST_STRPTR)GetMBString(MSG_RA_TitlesFrom1);
 	object->RA_TitlesFromContent[2] = NULL;
+
+	object->CY_FilterListContent[0] = (CONST_STRPTR)GetMBString(MSG_FilterShowAll);
+	object->CY_FilterListContent[1] = (CONST_STRPTR)GetMBString(MSG_FilterFavorites);
+	object->CY_FilterListContent[2] = (CONST_STRPTR)GetMBString(MSG_FilterLastPlayed);
+	object->CY_FilterListContent[3] = (CONST_STRPTR)GetMBString(MSG_FilterMostPlayed);
+	object->CY_FilterListContent[4] = (CONST_STRPTR)GetMBString(MSG_FilterNeverPlayed);
+	object->CY_FilterListContent[5] = NULL;
 
 	LA_Filter = Label(GetMBString(MSG_LA_Filter));
 
@@ -544,6 +553,12 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 
 		object->Space_Sidepanel = VSpace(1);
 
+		object->CY_FilterList = CycleObject,
+			MUIA_HelpNode, "CY_FilterList",
+			MUIA_Frame, MUIV_Frame_Button,
+			MUIA_Cycle_Entries, object->CY_FilterListContent,
+			End;
+
 		object->LV_GenresList = ListObject,
 			MUIA_Frame, MUIV_Frame_InputList,
 			MUIA_List_Active, MUIV_List_Active_Top,
@@ -575,10 +590,16 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 				End;
 		}
 
+		object->GR_leftpanel = GroupObject,
+			MUIA_HelpNode, "GR_leftpanel",
+			Child, object->CY_FilterList,
+			Child, object->LV_GamesList,
+			End;
+
 		GR_main = GroupObject,
 			MUIA_HelpNode, "GR_main",
 			MUIA_Group_Horiz, TRUE,
-			Child, object->LV_GamesList,
+			Child, object->GR_leftpanel,
 			Child, BalanceObject,
 				MUIA_CycleChain, 1,
 				MUIA_ObjectID, MAKE_ID('B', 'A', 'L', 0),
@@ -1322,6 +1343,13 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 			MUIM_CallHook, &FilterChangeHook
 		);
 	}
+
+	DoMethod(object->CY_FilterList,
+		MUIM_Notify, MUIA_Cycle_Active, MUIV_EveryTime,
+		object->App,
+		2,
+		MUIM_CallHook, &GenreClickHook
+	);
 
 	DoMethod(object->LV_GamesList,
 		MUIM_Notify, MUIA_NList_Active, MUIV_EveryTime,

--- a/src/iGameGUI.h
+++ b/src/iGameGUI.h
@@ -35,12 +35,14 @@ struct ObjApp
 	APTR WI_MainWindow;
 	APTR MN_MainMenu;
 	APTR STR_Filter;
+	APTR GR_leftpanel;
 	APTR GR_sidepanel;
 	APTR GR_spacedScreenshot;
 	APTR IM_GameImage_0;
 	APTR IM_GameImage_1;
 	APTR Space_Sidepanel;
 	APTR LV_GamesList;
+	APTR CY_FilterList;
 	APTR LV_GenresList;
 	APTR TX_Status;
 	APTR WI_Properties;
@@ -94,6 +96,7 @@ struct ObjApp
 	CONST_STRPTR CY_PropertiesGenreContent[512];
 	CONST_STRPTR CY_ScreenshotSizeContent[4];
 	CONST_STRPTR RA_TitlesFromContent[3];
+	CONST_STRPTR CY_FilterListContent[6];
 };
 
 struct ObjApp *CreateApp(void);


### PR DESCRIPTION
With this PR I moved the filter options from the Genre list to a new cycle box above the entries list. Now the user can make a selection of a specific genre and Last played or Favourites. So, the results can be a combination of the show filter and the genre and of course the title.

![Screenshot from 2023-07-16 20-45-22](https://github.com/MrZammler/iGame/assets/14014909/d0e78495-fd4c-42fc-bded-ad4c3cefd73a)
