### PR TITLE
Chipset filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
-### Changed
-- When realtime filtering is enabled at least 3 characters are required so as to be initiated. Less than 3 characters are ignored, unless the filtering by pressing the enter button is enabled.
-
-## iGame 2.4.0 - [2023-05-13]
 ### Added
 - Now the Genre list is populated from the igame.data files and the genre file, if it exists, although it is not necessary. The genre filtering is working with these new values
+
+### Changed
+- When realtime filtering is enabled at least 3 characters are required so as to be initiated. Less than 3 characters are ignored, unless the filtering by pressing the enter button is enabled.
+- Removed the filtering options from the Genre list and moved to its own select box above entries list
 
 ### Fixed
 - Fixed a hit when the entry properties are requested without having a selected entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
 ### Added
 - Now the Genre list is populated from the igame.data files and the genre file, if it exists, although it is not necessary. The genre filtering is working with these new values
+- Added a new cycle box that lets the user to filter the results based on the chipset. This requires in settings the "Prefer igame.data files" to be enabled
 
 ### Changed
 - When realtime filtering is enabled at least 3 characters are required so as to be initiated. Less than 3 characters are ignored, unless the filtering by pressing the enter button is enabled.
 - Removed the filtering options from the Genre list and moved to its own select box above entries list
+- Now, even if the list entries list is populated a new repository scan will update the Chipset and Genre information based on the data found in igame.data files.
+- If the "Prefer igame.data files" is not enabled those files are not used during the scan of repositories
 
 ### Fixed
 - Fixed a hit when the entry properties are requested without having a selected entry

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -99,7 +99,8 @@ endif
 
 igame_OBJS	= src/funcs_$(CPU).o src/iGameGUI_$(CPU).o \
 	src/iGameMain_$(CPU).o src/strfuncs_$(CPU).o src/fsfuncs_$(CPU).o \
-	src/slavesList_$(CPU).o src/genresList_$(CPU).o
+	src/slavesList_$(CPU).o src/genresList_$(CPU).o \
+	src/chipsetList_$(CPU).o
 
 ##########################################################################
 # Rule for building
@@ -127,7 +128,8 @@ catalogs/%/iGame.catalog: catalogs/%/iGame.ct catalogs/iGame.cd
 	@$(CC) -c $< -o $*_$(CPU).o $(CFLAGS) $(INCLUDES)
 
 src/funcs_$(CPU).o: src/funcs.c src/iGame_strings.h src/strfuncs.h \
-	src/fsfuncs.h src/iGameExtern.h src/slavesList.h src/genresList.h
+	src/fsfuncs.h src/iGameExtern.h src/slavesList.h src/genresList.h \
+	src/chipsetList.h
 
 src/iGameGUI_$(CPU).o: src/iGameGUI.c src/iGameGUI.h src/iGame_strings.h \
 	src/fsfuncs.h src/iGameExtern.h
@@ -137,11 +139,13 @@ src/iGameMain_$(CPU).o: src/iGameMain.c src/iGameExtern.h
 src/strfuncs_$(CPU).o: src/strfuncs.c src/iGameExtern.h src/strfuncs.h
 
 src/fsfuncs_$(CPU).o: src/fsfuncs.c src/fsfuncs.h src/funcs.h \
-	src/iGameExtern.h src/slavesList.h src/genresList.h
+	src/iGameExtern.h src/slavesList.h src/genresList.h src/chipsetList.h
 
 src/slavesList_$(CPU).o: src/slavesList.c src/slavesList.h
 
-src/genresList_$(CPU).o: src/genresList.c src/genresList.h
+src/genresList_$(CPU).o: src/genresList.c src/genresList.h src/strfuncs.h
+
+src/chipsetList_$(CPU).o: src/chipsetList.c src/chipsetList.h src/strfuncs.h
 
 ##########################################################################
 # generic rules

--- a/catalogs/iGame.cd
+++ b/catalogs/iGame.cd
@@ -248,7 +248,7 @@ MSG_FilterShowAll (//)
 --Show All--
 ;
 MSG_FilterFavorites (//)
---Favorites--
+--Favourites--
 ;
 MSG_FilterLastPlayed (//)
 --Last Played--
@@ -299,7 +299,7 @@ MSG_DirectoryNotFound (//)
 Game Directory not found!
 ;
 MSG_LA_StartWithFavorites (//)
-Display favorites on start
+Display favourites on start
 ;
 MSG_MNMainOpenCurrentDir (//)
 Open game folder

--- a/required_files/iGame.guide
+++ b/required_files/iGame.guide
@@ -17,7 +17,7 @@ iGame
 
 @{" Installation    " LINK "INST" 0} - How to install iGame
 @{" Usage           " LINK "USAG" 0} - Using iGame
-@{" igame.data      " LINK "IGDF" 0} - About igame.data files
+@{" igame.data file " LINK "IGDF" 0} - About igame.data files
 
 @{" Todo & Bugs     " LINK "TODO" 0} - Todo and known bugs
 @{" Author          " LINK "INFO" 0} - Author contact info
@@ -239,13 +239,15 @@ This menu opens the MUI Settings window, where you can change the look of MUI co
 @{lindent 3}
 The Main Window is what you see when you start iGame. It is pretty simple to use and it has only a few fields.
 
-At the top, there is the "Filter" field which is used to filter the list of entries, based on your input. iGame returns entries with a matching part in their title. For example, if you want to find all the games that have "Soccer" in their title, that's what you need to write. The search is not case-sensitive, so it doesn't matter if the part of the title is capitalized or not. From the iGame settings, you can set it when the search is initialized, while you type or after you press "Enter".
+At the top, there is the "Filter" field which is used to filter the list of entries, based on your input. iGame returns entries with a matching part in their title. For example, if you want to find all the games that have "Soccer" in their title, that's what you need to write. The search is not case-sensitive, so it doesn't matter if the part of the title is capitalized or not. From the iGame settings, you can set it when the search is initialized, while you type (3 minimum characters) or after you press "Enter".
 
-On the left side, there is the list, where all the entries (games, demos etc.) are shown. With a double click on an entry, it is executed. If you want to add some information on an entry using the "Game > Properties..." menu, that's the list where you have to select it first.
+On the left side, there are a filter select box and the entries list. The filter select box helps tp filter the entries by "Last played", "Favorites", "Most Played" and "Never Played".
 
-At the top right side, there is a screenshot of the selected entry. For the screenshot, iGame uses an image file, which must be in the same folder as the game/demo, named @{b}igame.iff@{ub}. If no screenshot is available then the game icon is shown. You can disable the screenshots from the @{" Settings Window " LINK "WINSETS" 0}.
+The entries list holds the entries (games, demos etc.) based on the filtering. With a double click on an entry, it is executed. If you want to add some information on an entry using the "Game > Properties..." menu, that's the list where you have to select it first. The list has 3 columns, where the first one has the title, the second one shows the year of release and the third column shows the maximum number of players that can play. iGame uses @{" igame.data files " LINK "IGDF" 0} to gather that information. By clicking on their title the sorting of the list can change.
 
-Under the screenshot, there is the "Genres" list which helps you filter the games based on the "Genre", as well as by "Last played", "Favorites", "Most Played" and "Never Played". There is also an "Unknown" selection which shows the entries that do not have any Genre assigned.
+At the top right side, there is a screenshot of the selected entry. For the screenshot, iGame uses an image file, which must be in the same folder as the game/demo, named @{b}igame.iff@{ub}. If no screenshot is available then the entry icon is shown. You can disable the screenshots from the @{" Settings Window " LINK "WINSETS" 0}.
+
+Under the screenshot, there is the "Genres" list which helps you filter the games based on the "Genre". There is also an "Unknown" selection which shows the entries that do not have any Genre assigned.
 
 At the bottom, there is a read-only field which shows information about iGame, based on what you are doing. It is like a status bar, where useful information will be shown while you use iGame.
 

--- a/required_files/iGame.guide
+++ b/required_files/iGame.guide
@@ -247,9 +247,13 @@ The entries list holds the entries (games, demos etc.) based on the filtering. W
 
 At the top right side, there is a screenshot of the selected entry. For the screenshot, iGame uses an image file, which must be in the same folder as the game/demo, named @{b}igame.iff@{ub}. If no screenshot is available then the entry icon is shown. You can disable the screenshots from the @{" Settings Window " LINK "WINSETS" 0}.
 
-Under the screenshot, there is the "Genres" list which helps you filter the games based on the "Genre". There is also an "Unknown" selection which shows the entries that do not have any Genre assigned.
+Under the screenshot, there is the Chipset cycle box. Using that the user can filter the games based on the required chipset, for example show only the AGA games.
+
+Then the "Genres" list helps the user to filter the games based on the "Genre". There is also an "Unknown" selection which shows the entries that do not have any Genre assigned.
 
 At the bottom, there is a read-only field which shows information about iGame, based on what you are doing. It is like a status bar, where useful information will be shown while you use iGame.
+
+The Genre and Chipset lists get the information from the @{b}gameslist.csv@{ub} file. It can be automatically populated if the @{" igame.data files " LINK "IGDF" 0} are used and this is enabled in the settings window.
 
 @ENDNODE
 @NODE "WINADDG" "Add a Game Window..."

--- a/src/chipsetList.c
+++ b/src/chipsetList.c
@@ -1,6 +1,6 @@
 /*
-  genresList.c
-  genres list functions source for iGame
+  chipsetList.c
+  chipset list functions source for iGame
 
   Copyright (c) 2018-2023, Emmanuel Vasilakis
 
@@ -27,30 +27,30 @@
 #include <exec/types.h>
 
 #include "iGameExtern.h"
-#include "genresList.h"
+#include "chipsetList.h"
 #include "strfuncs.h"
 
-genresList *genresListHead = NULL;
+chipsetList *chipsetListHead = NULL;
 
 static int isListEmpty(const void *head)
 {
 	return head == NULL;
 }
 
-void genresListAddTail(genresList *node)
+void chipsetListAddTail(chipsetList *node)
 {
 	if (node != NULL)
 	{
 		node->next = NULL;
 
-		if (isListEmpty(genresListHead))
+		if (isListEmpty(chipsetListHead))
 		{
-			genresListHead = node;
+			chipsetListHead = node;
 		}
 		else
 		{
 			// find the last node
-			genresList *currPtr = genresListHead;
+			chipsetList *currPtr = chipsetListHead;
 			while (currPtr->next != NULL)
 			{
 				currPtr = currPtr->next;
@@ -61,22 +61,22 @@ void genresListAddTail(genresList *node)
 	}
 }
 
-static BOOL genresListRemoveHead(void) {
+static BOOL chipsetListRemoveHead(void) {
 
-	if (isListEmpty(genresListHead)) {
+	if (isListEmpty(chipsetListHead)) {
 		return FALSE;
 	}
 
-	genresList *nextPtr = genresListHead->next;
-	free(genresListHead);
-	genresListHead = nextPtr;
+	chipsetList *nextPtr = chipsetListHead->next;
+	free(chipsetListHead);
+	chipsetListHead = nextPtr;
 	return TRUE;
 }
 
-void genresListPrint(void)
+void chipsetListPrint(void)
 {
 	int cnt = 0;
-	genresList *currPtr = genresListHead;
+	chipsetList *currPtr = chipsetListHead;
 	while (currPtr != NULL)
 	{
 		printf("----> %s\n", currPtr->title);
@@ -86,14 +86,14 @@ void genresListPrint(void)
 	printf("END OF LIST: %d items\n", cnt);
 }
 
-genresList *genresListSearchByTitle(char *title, unsigned int titleSize)
+chipsetList *chipsetListSearchByTitle(char *title, unsigned int titleSize)
 {
-	if (isListEmpty(genresListHead))
+	if (isListEmpty(chipsetListHead))
 	{
 		return NULL;
 	}
 
-	genresList *currPtr = genresListHead;
+	chipsetList *currPtr = chipsetListHead;
 	while (
 		currPtr != NULL &&
 		strncmp(currPtr->title, title, titleSize)
@@ -104,18 +104,18 @@ genresList *genresListSearchByTitle(char *title, unsigned int titleSize)
 	return currPtr;
 }
 
-genresList *getGenresListHead(void)
+chipsetList *getChipsetListHead(void)
 {
-	return genresListHead;
+	return chipsetListHead;
 }
 
-void emptyGenresList(void)
+void emptyChipsetList(void)
 {
-	while(genresListRemoveHead())
+	while(chipsetListRemoveHead())
 	{}
 }
 
-int genresListNodeCount(int cnt)
+int chipsetListNodeCount(int cnt)
 {
 	static int nodeCount = 0;
 
@@ -128,19 +128,19 @@ int genresListNodeCount(int cnt)
 	return nodeCount;
 }
 
-void addGenreInList(char *title)
+void addChipsetInList(char *title)
 {
 	if (isStringEmpty(title))
 		return;
 
-	if (genresListSearchByTitle(title, sizeof(char) * MAX_GENRE_NAME_SIZE) == NULL)
+	if (chipsetListSearchByTitle(title, sizeof(char) * MAX_CHIPSET_SIZE) == NULL)
 	{
-		genresList *node = malloc(sizeof(genresList));
+		chipsetList *node = malloc(sizeof(chipsetList));
 		if(node == NULL)
 		{
 			return;
 		}
-		strncpy(node->title, title, sizeof(char) * MAX_GENRE_NAME_SIZE);
-		genresListAddTail(node);
+		strncpy(node->title, title, sizeof(char) * MAX_CHIPSET_SIZE);
+		chipsetListAddTail(node);
 	}
 }

--- a/src/chipsetList.h
+++ b/src/chipsetList.h
@@ -1,0 +1,34 @@
+/*
+  chipsetList.h
+  chipset list functions header for iGame
+
+  Copyright (c) 2018-2023, Emmanuel Vasilakis
+
+  This file is part of iGame.
+
+  iGame is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  iGame is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with iGame. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _CHIPSET_LIST_H
+#define _CHIPSET_LIST_H
+
+void chipsetListAddTail(chipsetList *);
+void chipsetListPrint(void);
+chipsetList *chipsetListSearchByTitle(char *, unsigned int);
+chipsetList *getChipsetListHead(void);
+void emptyChipsetList(void);
+int chipsetListNodeCount(int);
+void addChipsetInList(char *);
+
+#endif

--- a/src/fsfuncs.c
+++ b/src/fsfuncs.c
@@ -55,6 +55,7 @@
 #include "strfuncs.h"
 #include "slavesList.h"
 #include "genresList.h"
+#include "chipsetList.h"
 #include "funcs.h"
 #include "fsfuncs.h"
 
@@ -267,6 +268,18 @@ void slavesListLoadFromCSV(char *filename)
 				if (buf)
 					node->players = atoi(buf);
 
+				buf = strtok(NULL, ";");
+				node->chipset[0] = '\0';
+				if (strncmp(buf, "\n", sizeof(char)))
+				{
+					sprintf(node->chipset, "%s", buf);
+				}
+				if (strcasestr(buf, "\""))
+				{
+					sprintf(node->chipset, "%s", substring(buf, 1, -2));
+				}
+				addChipsetInList(node->chipset);
+
 				slavesListAddTail(node);
 			}
 			Close(fpgames);
@@ -298,12 +311,12 @@ void slavesListSaveToCSV(const char *filename)
 	{
 		fprintf(
 			fpgames,
-			"%d;\"%s\";\"%s\";\"%s\";%d;%d;%d;%d;%d;\"%s\";%d;%d;\n",
+			"%d;\"%s\";\"%s\";\"%s\";%d;%d;%d;%d;%d;\"%s\";%d;%d;\"%s\";\n",
 			currPtr->instance, currPtr->title,
 			currPtr->genre, currPtr->path, currPtr->favourite,
 			currPtr->times_played, currPtr->last_played, currPtr->hidden,
 			currPtr->deleted, currPtr->user_title,
-			currPtr->year, currPtr->players
+			currPtr->year, currPtr->players, currPtr->chipset
 		);
 		currPtr = currPtr->next;
 	}
@@ -668,6 +681,11 @@ void getIGameDataInfo(char *igameDataPath, slavesList *node)
 				if(current_settings->useIgameDataTitle && !strcmp(tmpTbl[0], "title"))
 				{
 					strncpy(node->title, tmpTbl[1], MAX_SLAVE_TITLE_SIZE);
+				}
+
+				if(!strcmp(tmpTbl[0], "chipset"))
+				{
+					strncpy(node->chipset, tmpTbl[1], MAX_CHIPSET_SIZE);
 				}
 
 				if(!strcmp(tmpTbl[0], "genre"))

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -371,7 +371,6 @@ void app_start(void)
 	setStatusText(GetMBString(MSG_LoadingSavedList));
 	set(app->WI_MainWindow, MUIA_Window_Sleep, TRUE);
 	slavesListLoadFromCSV(csvFilename);
-	showSlavesList();
 
 	populateGenresList();
 	populateChipsetList();

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -401,10 +401,10 @@ void filter_change(void)
 	}
 	else filters.title[0] = '\0';
 
-	if (!isStringEmpty(genreSelection))
+	if (genreSelection)
 		strncpy(filters.showGenre, genreSelection, sizeof(filters.showGenre));
 
-	if (genreSelection == NULL || !strcmp(genreSelection, GetMBString(MSG_FilterShowAll)))
+	if (!genreSelection || !strcmp(genreSelection, GetMBString(MSG_FilterShowAll)))
 		filters.showGenre[0] = '\0';
 
 	// Get selected chipset from the cycle box

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -68,7 +68,7 @@ char fname[255];
 BOOL sidepanelChanged = FALSE; // This is temporary until settings are revamped
 
 /* function definitions */
-static void add_default_filters(void);
+static int get_cycle_index(Object *);
 static void showSlavesList(void);
 static LONG xget(Object *, ULONG);
 
@@ -290,7 +290,8 @@ static void populateGenresList(void)
 	DoMethod(app->LV_GenresList, MUIM_List_Clear);
 	set(app->LV_GenresList, MUIA_List_Quiet, TRUE);
 
-	add_default_filters();
+	// Add Show All in genres list
+	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterShowAll), MUIV_List_Insert_Bottom);
 	loadGenresFromFile();
 	addGenreInList(GetMBString(MSG_UnknownGenre));
 
@@ -315,15 +316,6 @@ static void populateGenresList(void)
 	set(app->CY_PropertiesGenre, MUIA_Cycle_Entries, app->CY_PropertiesGenreContent);
 	set(app->CY_AddGameGenre, MUIA_Cycle_Entries, app->CY_PropertiesGenreContent);
 	set(app->LV_GenresList, MUIA_List_Quiet, FALSE);
-}
-
-static void add_default_filters(void)
-{
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterShowAll), MUIV_List_Insert_Bottom);
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterFavorites), MUIV_List_Insert_Bottom);
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterLastPlayed), MUIV_List_Insert_Bottom);
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterMostPlayed), MUIV_List_Insert_Bottom);
-	DoMethod(app->LV_GenresList, MUIM_List_InsertSingle, GetMBString(MSG_FilterNeverPlayed), MUIV_List_Insert_Bottom);
 }
 
 // Clears the list of items
@@ -372,6 +364,7 @@ void filter_change(void)
 	char *title = NULL;
 	char *genreSelection = NULL;
 	filters.showGenre[0] = '\0';
+	filters.showGroup = get_cycle_index(app->CY_FilterList);
 
 	get(app->STR_Filter, MUIA_String_Contents, &title);
 	if (!current_settings->filter_use_enter && strlen(title) > 0 && strlen(title) < MIN_TITLE_FILTER_CHARS) {
@@ -388,22 +381,11 @@ void filter_change(void)
 	}
 	else filters.title[0] = '\0';
 
+	if (!isStringEmpty(genreSelection))
+		strncpy(filters.showGenre, genreSelection, sizeof(filters.showGenre));
+
 	if (genreSelection == NULL || !strcmp(genreSelection, GetMBString(MSG_FilterShowAll)))
-		filters.showGroup = GROUP_SHOWALL;
-
-	else if (!strcmp(genreSelection, GetMBString(MSG_FilterFavorites)))
-		filters.showGroup = GROUP_FAVOURITES;
-
-	else if (!strcmp(genreSelection, GetMBString(MSG_FilterLastPlayed)))
-		filters.showGroup = GROUP_LAST_PLAYED;
-
-	else if (!strcmp(genreSelection, GetMBString(MSG_FilterMostPlayed)))
-		filters.showGroup = GROUP_MOST_PLAYED;
-
-	else if (!strcmp(genreSelection, GetMBString(MSG_FilterNeverPlayed)))
-		filters.showGroup = GROUP_NEVER_PLAYED;
-
-	else strncpy(filters.showGenre, genreSelection, sizeof(filters.showGenre));
+		filters.showGenre[0] = '\0';
 
 	showSlavesList();
 }

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -57,6 +57,7 @@
 #include "fsfuncs.h"
 #include "slavesList.h"
 #include "genresList.h"
+#include "chipsetList.h"
 #include "funcs.h"
 
 extern struct ObjApp* app;
@@ -309,13 +310,30 @@ static void populateGenresList(void)
 	int i = 0;
 	for (i = 0; i < genresListNodeCount(cnt); i++)
 	{
-		DoMethod(app->LV_GenresList, MUIM_List_GetEntry, i+5, &app->CY_PropertiesGenreContent[i]);
+		DoMethod(app->LV_GenresList, MUIM_List_GetEntry, i+1, &app->CY_PropertiesGenreContent[i]);
 	}
 	app->CY_PropertiesGenreContent[i] = (unsigned char*)GetMBString(MSG_UnknownGenre);
 	app->CY_PropertiesGenreContent[i++] = NULL;
 	set(app->CY_PropertiesGenre, MUIA_Cycle_Entries, app->CY_PropertiesGenreContent);
 	set(app->CY_AddGameGenre, MUIA_Cycle_Entries, app->CY_PropertiesGenreContent);
 	set(app->LV_GenresList, MUIA_List_Quiet, FALSE);
+}
+
+static void populateChipsetList(void)
+{
+	chipsetList *currPtr = getChipsetListHead();
+
+	int cnt = 1;
+	app->CY_ChipsetListContent[cnt] = (unsigned char*)GetMBString(MSG_FilterShowAll);
+	while (currPtr != NULL)
+	{
+		app->CY_ChipsetListContent[cnt] = currPtr->title;
+		cnt++;
+		currPtr = currPtr->next;
+	}
+
+	app->CY_ChipsetListContent[cnt++] = NULL;
+	set(app->CY_ChipsetList, MUIA_Cycle_Entries, app->CY_ChipsetListContent);
 }
 
 // Clears the list of items
@@ -355,6 +373,7 @@ void app_start(void)
 	showSlavesList();
 
 	populateGenresList();
+	populateChipsetList();
 	set(app->WI_MainWindow, MUIA_Window_Sleep, FALSE);
 	set(app->WI_MainWindow, MUIA_Window_ActiveObject, app->LV_GamesList);
 }
@@ -365,6 +384,7 @@ void filter_change(void)
 	char *genreSelection = NULL;
 	filters.showGenre[0] = '\0';
 	filters.showGroup = get_cycle_index(app->CY_FilterList);
+	filters.showChipset[0] = '\0';
 
 	get(app->STR_Filter, MUIA_String_Contents, &title);
 	if (!current_settings->filter_use_enter && strlen(title) > 0 && strlen(title) < MIN_TITLE_FILTER_CHARS) {
@@ -386,6 +406,12 @@ void filter_change(void)
 
 	if (genreSelection == NULL || !strcmp(genreSelection, GetMBString(MSG_FilterShowAll)))
 		filters.showGenre[0] = '\0';
+
+	// Get selected chipset from the cycle box
+	int chipsetIndex = get_cycle_index(app->CY_ChipsetList);
+	strncpy(filters.showChipset, app->CY_ChipsetListContent[chipsetIndex], sizeof(filters.showChipset));
+	if (chipsetIndex == 0)
+		filters.showChipset[0] = '\0';
 
 	showSlavesList();
 }
@@ -593,6 +619,15 @@ static void showSlavesList(void)
 				goto nextItem;
 			}
 
+			// Filter the list by the selected chipset
+			if (
+				!isStringEmpty(filters.showChipset) &&
+				strncmp(filters.showChipset, currPtr->chipset, sizeof(currPtr->chipset))
+			)
+			{
+				goto nextItem;
+			}
+
 			// Decide from where the item name will be taken
 			if(!isStringEmpty(currPtr->user_title))
 			{
@@ -741,7 +776,7 @@ static BOOL examineFolder(char *path)
 				{
 
 					// igame.data found
-					if (!strcmp(FIblock->fib_FileName, DEFAULT_IGAMEDATA_FILE))
+					if (current_settings->useIgameDataTitle && !strcmp(FIblock->fib_FileName, DEFAULT_IGAMEDATA_FILE))
 					{
 						slavesList *node = malloc(sizeof(slavesList));
 						if(node == NULL)
@@ -769,6 +804,7 @@ static BOOL examineFolder(char *path)
 						node->genre[0] = '\0';
 						node->user_title[0] = '\0';
 						node->arguments[0] = '\0';
+						node->chipset[0] = '\0';
 						node->times_played = 0;
 						node->favourite = 0;
 						node->last_played = 0;
@@ -800,6 +836,7 @@ static BOOL examineFolder(char *path)
 						{
 							slavesListAddTail(node);
 							addGenreInList(node->genre);
+							addChipsetInList(node->chipset);
 						}
 					}
 
@@ -834,6 +871,7 @@ static BOOL examineFolder(char *path)
 							node->title[0] = '\0';
 							node->genre[0] = '\0';
 							node->user_title[0] = '\0';
+							node->chipset[0] = '\0';
 							node->times_played = 0;
 							node->favourite = 0;
 							node->last_played = 0;
@@ -846,16 +884,19 @@ static BOOL examineFolder(char *path)
 							getFullPath(buf, buf);
 							strncpy(node->path, buf, sizeof(node->path));
 
-							// TODO: Add here if igame.data is enabled to be used in settings
-							char *igameDataPath = malloc(sizeof(char) * MAX_PATH_SIZE);
-							snprintf(igameDataPath, sizeof(char) * MAX_PATH_SIZE, "%s/%s", path, DEFAULT_IGAMEDATA_FILE);
-							if (check_path_exists(igameDataPath))
+							// if igame.data is enabled in settings use it
+							if (current_settings->useIgameDataTitle)
 							{
-								getIGameDataInfo(igameDataPath, node);
+								char *igameDataPath = malloc(sizeof(char) * MAX_PATH_SIZE);
+								snprintf(igameDataPath, sizeof(char) * MAX_PATH_SIZE, "%s/%s", path, DEFAULT_IGAMEDATA_FILE);
+								if (check_path_exists(igameDataPath))
+								{
+									getIGameDataInfo(igameDataPath, node);
+								}
 							}
 
 							// Generate title and add in the list
-							// TODO: Run the following if igame.data is disabled or if the node->title is still empty
+							// Run the following if the node->title is empty
 							if (isStringEmpty(node->title))
 							{
 								generateItemName(node->path, node->title, sizeof(node->title));
@@ -867,9 +908,40 @@ static BOOL examineFolder(char *path)
 							// TODO: IDEA - Instead of adding at the tail insert it in sorted position
 							slavesListAddTail(node);
 							addGenreInList(node->genre);
+							addChipsetInList(node->chipset);
 						}
 						else
 						{
+							if (current_settings->useIgameDataTitle)
+							{
+								slavesList *node = malloc(sizeof(slavesList));
+								if(node == NULL)
+								{
+									msg_box((const char*)GetMBString(MSG_NotEnoughMemory));
+									FreeVec(FIblock);
+									UnLock(lock);
+									free(buf);
+									return FALSE;
+								}
+
+								char *igameDataPath = malloc(sizeof(char) * MAX_PATH_SIZE);
+								snprintf(igameDataPath, sizeof(char) * MAX_PATH_SIZE, "%s/%s", existingNode->path, DEFAULT_IGAMEDATA_FILE);
+								if (check_path_exists(igameDataPath))
+								{
+									getIGameDataInfo(igameDataPath, node);
+								}
+
+								if (!isStringEmpty(node->genre))
+									strncpy(existingNode->genre, node->genre, MAX_GENRE_NAME_SIZE);
+
+								if (!isStringEmpty(node->chipset))
+								strncpy(existingNode->chipset, node->chipset, MAX_CHIPSET_SIZE);
+
+								addGenreInList(node->genre);
+								addChipsetInList(node->chipset);
+								free(node);
+							}
+
 							// Generate title and add in the list
 							generateItemName(existingNode->path, existingNode->title, sizeof(existingNode->title));
 						}
@@ -903,6 +975,7 @@ void scan_repositories(void)
 		save_list();
 		showSlavesList();
 		populateGenresList();
+		populateChipsetList();
 		set(app->WI_MainWindow, MUIA_Window_Sleep, FALSE);
 	}
 }
@@ -913,6 +986,7 @@ static void applySidePanelChange(void)
 	{
 		DoMethod(app->GR_sidepanel, MUIM_Group_InitChange);
 		DoMethod(app->GR_sidepanel, OM_REMMEMBER, app->Space_Sidepanel);
+		DoMethod(app->GR_sidepanel, OM_REMMEMBER, app->CY_ChipsetList);
 		DoMethod(app->GR_sidepanel, OM_REMMEMBER, app->LV_GenresList);
 
 		if (!current_settings->hide_screenshots) {
@@ -947,6 +1021,7 @@ static void applySidePanelChange(void)
 		}
 
 		DoMethod(app->GR_sidepanel, OM_ADDMEMBER, app->Space_Sidepanel);
+		DoMethod(app->GR_sidepanel, OM_ADDMEMBER, app->CY_ChipsetList);
 		DoMethod(app->GR_sidepanel, OM_ADDMEMBER, app->LV_GenresList);
 		DoMethod(app->GR_sidepanel, MUIM_Group_ExitChange);
 	}
@@ -1315,11 +1390,6 @@ void app_stop(void)
 		free(repos);
 		repos = NULL;
 	}
-}
-
-void genres_click(void)
-{
-	filter_change();
 }
 
 void save_list(void)

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -357,6 +357,7 @@ void app_start(void)
 	if (current_settings->start_with_favorites)
 	{
 		filters.showGroup = GROUP_FAVOURITES;
+		set(app->CY_FilterList, MUIA_Cycle_Active, GROUP_FAVOURITES);
 	}
 
 	DoMethod(app->App,

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -41,7 +41,6 @@ void app_start(void);
 void slaveProperties(void);
 void saveItemProperties(void);
 void add_non_whdload(void);
-void genres_click(void);
 void non_whdload_ok(void);
 void repo_stop(void);
 void repo_add(void);

--- a/src/iGameExtern.h
+++ b/src/iGameExtern.h
@@ -70,6 +70,7 @@
 #define MAX_TOOLTYPE_SIZE 64
 #define MAX_ARGUMENTS_SIZE 64
 #define MIN_TITLE_FILTER_CHARS 3
+#define MAX_CHIPSET_SIZE 16
 
 typedef struct settings
 {
@@ -92,6 +93,12 @@ typedef struct genresList
 	struct genresList *next;
 } genresList;
 
+typedef struct chipsetList
+{
+	char title[MAX_CHIPSET_SIZE];
+	struct chipsetList *next;
+} chipsetList;
+
 typedef struct repos
 {
 	char repo[256];
@@ -105,6 +112,7 @@ typedef struct slavesList
 	char path[MAX_PATH_SIZE];
 	char genre[MAX_GENRE_NAME_SIZE];
 	char arguments[MAX_ARGUMENTS_SIZE];
+	char chipset[MAX_CHIPSET_SIZE];
 
 	int instance;
 	int times_played;
@@ -133,6 +141,7 @@ typedef struct listFilters
 	BOOL showHiddenOnly;
 	int showGroup;
 	char showGenre[MAX_GENRE_NAME_SIZE];
+	char showChipset[MAX_CHIPSET_SIZE];
 } listFilters;
 
 enum {

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -327,9 +327,9 @@ struct ObjApp *CreateApp(void)
 	static const struct Hook GameClickHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)game_click, NULL };
 #endif
 #if defined(__amigaos4__)
-	static const struct Hook GenreClickHook = { { NULL,NULL }, (HOOKFUNC)genres_click, NULL, NULL };
+	static const struct Hook GenreClickHook = { { NULL,NULL }, (HOOKFUNC)filter_change, NULL, NULL };
 #else
-	static const struct Hook GenreClickHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)genres_click, NULL };
+	static const struct Hook GenreClickHook = { { NULL,NULL }, HookEntry, (HOOKFUNC)filter_change, NULL };
 #endif
 #if defined(__amigaos4__)
 	static const struct Hook NonWHDLoadOKHook = { { NULL,NULL }, (HOOKFUNC)non_whdload_ok, NULL, NULL };
@@ -438,6 +438,9 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 	object->CY_FilterListContent[4] = (CONST_STRPTR)GetMBString(MSG_FilterNeverPlayed);
 	object->CY_FilterListContent[5] = NULL;
 
+	object->CY_ChipsetListContent[0] = (CONST_STRPTR)GetMBString(MSG_FilterShowAll);
+	object->CY_ChipsetListContent[1] = NULL;
+
 	LA_Filter = Label(GetMBString(MSG_LA_Filter));
 
 	object->STR_Filter = StringObject,
@@ -454,6 +457,7 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 		Child, object->STR_Filter,
 		End;
 
+	// TODO: Below comments need to be removed
 	// static const char *titles[] =
 	// {
 	// 	"Title",
@@ -559,6 +563,12 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 			MUIA_Cycle_Entries, object->CY_FilterListContent,
 			End;
 
+		object->CY_ChipsetList = CycleObject,
+			MUIA_HelpNode, "CY_ChipsetList",
+			MUIA_Frame, MUIV_Frame_Button,
+			MUIA_Cycle_Entries, object->CY_ChipsetListContent,
+			End;
+
 		object->LV_GenresList = ListObject,
 			MUIA_Frame, MUIV_Frame_InputList,
 			MUIA_List_Active, MUIV_List_Active_Top,
@@ -566,7 +576,6 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 
 		object->LV_GenresList = ListviewObject,
 			MUIA_HelpNode, "LV_GenresList",
-			MUIA_FrameTitle, GetMBString(MSG_LV_GenresListTitle),
 			MUIA_Listview_List, object->LV_GenresList,
 			End;
 
@@ -577,6 +586,7 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 				MUIA_Weight, 100,
 				Child, object->GR_spacedScreenshot,
 				Child, object->Space_Sidepanel,
+				Child, object->CY_ChipsetList,
 				Child, object->LV_GenresList,
 				End;
 		}
@@ -586,6 +596,7 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 				MUIA_HelpNode, "GR_sidepanel",
 				MUIA_Weight, 100,
 				Child, object->Space_Sidepanel,
+				Child, object->CY_ChipsetList,
 				Child, object->LV_GenresList,
 				End;
 		}
@@ -1345,6 +1356,13 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 	}
 
 	DoMethod(object->CY_FilterList,
+		MUIM_Notify, MUIA_Cycle_Active, MUIV_EveryTime,
+		object->App,
+		2,
+		MUIM_CallHook, &GenreClickHook
+	);
+
+	DoMethod(object->CY_ChipsetList,
 		MUIM_Notify, MUIA_Cycle_Active, MUIV_EveryTime,
 		object->App,
 		2,

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -421,13 +421,22 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 
 	object->CY_PropertiesGenreContent[0] = (CONST_STRPTR)GetMBString(MSG_CY_PropertiesGenre0);
 	object->CY_PropertiesGenreContent[1] = NULL;
+
 	object->CY_ScreenshotSizeContent[0] = (CONST_STRPTR)GetMBString(MSG_CY_ScreenshotSize0);
 	object->CY_ScreenshotSizeContent[1] = (CONST_STRPTR)GetMBString(MSG_CY_ScreenshotSize1);
 	object->CY_ScreenshotSizeContent[2] = (CONST_STRPTR)GetMBString(MSG_CY_ScreenshotSize2);
 	object->CY_ScreenshotSizeContent[3] = NULL;
+
 	object->RA_TitlesFromContent[0] = (CONST_STRPTR)GetMBString(MSG_RA_TitlesFrom0);
 	object->RA_TitlesFromContent[1] = (CONST_STRPTR)GetMBString(MSG_RA_TitlesFrom1);
 	object->RA_TitlesFromContent[2] = NULL;
+
+	object->CY_FilterListContent[0] = (CONST_STRPTR)GetMBString(MSG_FilterShowAll);
+	object->CY_FilterListContent[1] = (CONST_STRPTR)GetMBString(MSG_FilterFavorites);
+	object->CY_FilterListContent[2] = (CONST_STRPTR)GetMBString(MSG_FilterLastPlayed);
+	object->CY_FilterListContent[3] = (CONST_STRPTR)GetMBString(MSG_FilterMostPlayed);
+	object->CY_FilterListContent[4] = (CONST_STRPTR)GetMBString(MSG_FilterNeverPlayed);
+	object->CY_FilterListContent[5] = NULL;
 
 	LA_Filter = Label(GetMBString(MSG_LA_Filter));
 
@@ -544,6 +553,12 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 
 		object->Space_Sidepanel = VSpace(1);
 
+		object->CY_FilterList = CycleObject,
+			MUIA_HelpNode, "CY_FilterList",
+			MUIA_Frame, MUIV_Frame_Button,
+			MUIA_Cycle_Entries, object->CY_FilterListContent,
+			End;
+
 		object->LV_GenresList = ListObject,
 			MUIA_Frame, MUIV_Frame_InputList,
 			MUIA_List_Active, MUIV_List_Active_Top,
@@ -575,10 +590,16 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 				End;
 		}
 
+		object->GR_leftpanel = GroupObject,
+			MUIA_HelpNode, "GR_leftpanel",
+			Child, object->CY_FilterList,
+			Child, object->LV_GamesList,
+			End;
+
 		GR_main = GroupObject,
 			MUIA_HelpNode, "GR_main",
 			MUIA_Group_Horiz, TRUE,
-			Child, object->LV_GamesList,
+			Child, object->GR_leftpanel,
 			Child, BalanceObject,
 				MUIA_CycleChain, 1,
 				MUIA_ObjectID, MAKE_ID('B', 'A', 'L', 0),
@@ -1322,6 +1343,13 @@ MakeStaticHook(SettingUseIgameDataTitleHook, settingUseIgameDataTitleChanged);
 			MUIM_CallHook, &FilterChangeHook
 		);
 	}
+
+	DoMethod(object->CY_FilterList,
+		MUIM_Notify, MUIA_Cycle_Active, MUIV_EveryTime,
+		object->App,
+		2,
+		MUIM_CallHook, &GenreClickHook
+	);
 
 	DoMethod(object->LV_GamesList,
 		MUIM_Notify, MUIA_NList_Active, MUIV_EveryTime,

--- a/src/iGameGUI.h
+++ b/src/iGameGUI.h
@@ -44,6 +44,7 @@ struct ObjApp
 	APTR LV_GamesList;
 	APTR CY_FilterList;
 	APTR LV_GenresList;
+	APTR CY_ChipsetList;
 	APTR TX_Status;
 	APTR WI_Properties;
 	APTR STR_PropertiesGameTitle;
@@ -93,10 +94,11 @@ struct ObjApp
 	CONST_STRPTR STR_TX_PropertiesSlavePath;
 	CONST_STRPTR STR_TX_PropertiesTooltypes;
 	CONST_STRPTR STR_TX_About;
-	CONST_STRPTR CY_PropertiesGenreContent[512];
+	CONST_STRPTR CY_PropertiesGenreContent[128];
 	CONST_STRPTR CY_ScreenshotSizeContent[4];
 	CONST_STRPTR RA_TitlesFromContent[3];
 	CONST_STRPTR CY_FilterListContent[6];
+	CONST_STRPTR CY_ChipsetListContent[16];
 };
 
 struct ObjApp *CreateApp(void);

--- a/src/iGameGUI.h
+++ b/src/iGameGUI.h
@@ -35,12 +35,14 @@ struct ObjApp
 	APTR WI_MainWindow;
 	APTR MN_MainMenu;
 	APTR STR_Filter;
+	APTR GR_leftpanel;
 	APTR GR_sidepanel;
 	APTR GR_spacedScreenshot;
 	APTR IM_GameImage_0;
 	APTR IM_GameImage_1;
 	APTR Space_Sidepanel;
 	APTR LV_GamesList;
+	APTR CY_FilterList;
 	APTR LV_GenresList;
 	APTR TX_Status;
 	APTR WI_Properties;
@@ -94,6 +96,7 @@ struct ObjApp
 	CONST_STRPTR CY_PropertiesGenreContent[512];
 	CONST_STRPTR CY_ScreenshotSizeContent[4];
 	CONST_STRPTR RA_TitlesFromContent[3];
+	CONST_STRPTR CY_FilterListContent[6];
 };
 
 struct ObjApp *CreateApp(void);


### PR DESCRIPTION
With the PR I added a new cycle box above the Genre that has the chipset based on the information that is stored in the igame.data files. This way users can filter the items based on if it is an RTG, AGA or OCS/ECS etc.

![Screenshot from 2023-07-17 18-07-21](https://github.com/MrZammler/iGame/assets/14014909/9a8a3943-659d-4614-be65-28bd66787cdd)
