### PR TITLE
Fixes on renaming and single item addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
+### Fixed
+- Fixed the item (demo/game) renaming from the properties window
+- Fixed the addition of an item (demo/game) from the "Add game..." window. This was saved in a wrong way and was breaking the list
+
+## iGame 2.4.4 - [2023-09-11]
 ### Changed
 - Now after the repository scans, any item that is not assigned to any genre gets the "Unknown" value by default
 

--- a/src/fsfuncs.c
+++ b/src/fsfuncs.c
@@ -283,7 +283,6 @@ void slavesListLoadFromCSV(char *filename)
 				slavesListAddTail(node);
 			}
 			Close(fpgames);
-			// FreeVec(buf);
 			FreeVec(lineBuf);
 		}
 	}

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1344,11 +1344,11 @@ void saveItemProperties(void)
 	{
 		strncpy(node->user_title, buf, sizeof(node->user_title));
 
-		// TODO: Reduce duplication with below block
+		// TODO: Reduce duplication with the block below
 		set(app->LV_GamesList, MUIA_NList_Quiet, TRUE);
 		DoMethod(app->LV_GamesList, MUIM_NList_Remove, MUIV_NList_Remove_Active);
 		DoMethod(app->LV_GamesList,
-			MUIM_NList_InsertSingle, node->user_title,
+			MUIM_NList_InsertSingle, node,
 			MUIV_NList_Insert_Sorted);
 		get(app->LV_GamesList, MUIA_NList_InsertPosition, &newpos);
 		set(app->LV_GamesList, MUIA_NList_Active, newpos);
@@ -1364,7 +1364,7 @@ void saveItemProperties(void)
 		set(app->LV_GamesList, MUIA_NList_Quiet, TRUE);
 		DoMethod(app->LV_GamesList, MUIM_NList_Remove, MUIV_NList_Remove_Active);
 		DoMethod(app->LV_GamesList,
-			MUIM_NList_InsertSingle, node->title,
+			MUIM_NList_InsertSingle, node,
 			MUIV_NList_Insert_Sorted);
 		get(app->LV_GamesList, MUIA_NList_InsertPosition, &newpos);
 		set(app->LV_GamesList, MUIA_NList_Active, newpos);
@@ -1688,13 +1688,19 @@ void non_whdload_ok(void)
 	slavesList *node = malloc(sizeof(slavesList));
 
 	node->instance = 0;
+	node->title[0] = '\0';
 	node->user_title[0] = '\0';
+	node->genre[0] = '\0';
+	node->arguments[0] = '\0';
+	node->chipset[0] = '\0';
 	node->times_played = 0;
 	node->favourite = 0;
 	node->last_played = 0;
 	node->exists = 1;
 	node->hidden = 0;
 	node->deleted = 0;
+	node->year = 0;
+	node->players = 0;
 
 	get(app->PA_AddGame, MUIA_String_Contents, &path);
 	getFullPath(path, node->path);
@@ -1722,7 +1728,7 @@ void non_whdload_ok(void)
 
 	set(app->LV_GamesList, MUIA_NList_Quiet, TRUE);
 	DoMethod(app->LV_GamesList,
-		MUIM_NList_InsertSingle, node->title,
+		MUIM_NList_InsertSingle, node,
 		MUIV_NList_Insert_Sorted);
 	get(app->LV_GamesList, MUIA_NList_InsertPosition, &newpos);
 	set(app->LV_GamesList, MUIA_NList_Active, newpos);


### PR DESCRIPTION
With these changes I fixed the renaming of an item from the properties window
Also, made a few fixes on single item addition from the "Add game" window. This is initiated from the "Add game..." menu item