### PR TITLE
Fixed the opening of the properties window for some users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
+### Fixed
+- Fixed the opening of the properties window for some users, by reverting some changes from v2.4.1
+
+## iGame 2.4.4 - [2023-09-11]
 ### Changed
 - Now after the repository scans, any item that is not assigned to any genre gets the "Unknown" value by default
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -1279,8 +1279,9 @@ void repo_stop(void)
 // Shows the Properties window populating the information fields
 void slaveProperties(void)
 {
-	char *title;
-	if ((title = (char *)DoMethod(app->LV_GamesList, MUIM_NList_GetEntry, MUIV_NList_GetEntry_Active, NULL)) == NULL)
+	char *title = NULL;
+	DoMethod(app->LV_GamesList, MUIM_NList_GetEntry, MUIV_NList_GetEntry_Active, &title);
+	if(isStringEmpty(title))
 	{
 		msg_box((const char*)GetMBString(MSG_SelectGameFromList));
 		return;

--- a/src/strfuncs.c
+++ b/src/strfuncs.c
@@ -304,6 +304,9 @@ STRPTR GetMBString(ULONG refId)
 
 BOOL isStringEmpty(const char *string)
 {
+	if (string == NULL)
+		return TRUE;
+
 	return string[0] == '\0';
 }
 


### PR DESCRIPTION
Some users have an issue on opening the properties of an item, which is not working for them since v2.4.1
This PR is for fixing that