### PR TITLE
Fixing the issue 215 and make the scan better on changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed the generated genre list titles after a rescan of the repository
 - Fixed more memory leaks
 - Fixed the load of the list of items when the side panel is hidden
+- Fixed the title change of the items in the list (#215)
 
 ## iGame 2.4.3 - [2023-09-01]
 ### Fixed

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -72,6 +72,7 @@ BOOL sidepanelChanged = FALSE; // This is temporary until settings are revamped
 static int get_cycle_index(Object *);
 static void showSlavesList(void);
 static LONG xget(Object *, ULONG);
+static void setLastScanBitfield(void);
 
 repos_list *item_repos = NULL, *repos = NULL;
 igame_settings *current_settings = NULL;
@@ -143,6 +144,7 @@ static void setDefaultSettings(igame_settings *settings)
 	current_settings->screenshot_width		= 160;
 	current_settings->screenshot_height		= 128;
 	current_settings->start_with_favorites	= FALSE;
+	current_settings->lastScanSetup			= 0;
 }
 
 static void getPrefsPath(STRPTR prefsPath, STRPTR prefsFile)
@@ -221,12 +223,17 @@ igame_settings *load_settings(const char* filename)
 					current_settings->start_with_favorites = atoi((const char*)file_line + 21);
 				if (!strncmp(file_line, "use_igame.data_title=", 21))
 					current_settings->useIgameDataTitle = atoi((const char*)file_line + 21);
+				if (!strncmp(file_line, "last_scan_setup=", 16))
+					current_settings->lastScanSetup = atoi((const char*)file_line + 16);
 			}
 			while (1);
 
 			Close(fpsettings);
 		}
 	}
+
+	if (current_settings->lastScanSetup == 0)
+		setLastScanBitfield();
 
 	if (prefsPath)
 		FreeVec(prefsPath);
@@ -740,6 +747,23 @@ static void generateItemName(char *path, char *result, int resultSize)
 	}
 }
 
+static uint8_t calcLastScanBitfield(void)
+{
+	uint8_t scanBitfield = 0;
+	scanBitfield = 1 * current_settings->useIgameDataTitle;
+	scanBitfield += 2 * current_settings->titles_from_dirs;
+	if(current_settings->titles_from_dirs)
+	{
+		scanBitfield += 4 * current_settings->no_smart_spaces;
+	}
+	return scanBitfield;
+}
+
+static void setLastScanBitfield(void)
+{
+	current_settings->lastScanSetup = calcLastScanBitfield();
+}
+
 static BOOL examineFolder(char *path)
 {
 	BOOL success = TRUE;
@@ -966,6 +990,13 @@ static BOOL examineFolder(char *path)
 
 									getIGameDataInfo(igameDataPath, node);
 
+									strncpy(existingNode->title, node->title, MAX_SLAVE_TITLE_SIZE);
+									if (isStringEmpty(existingNode->title))
+									{
+										// Fallback generation of the title and addition in the list
+										generateItemName(existingNode->path, existingNode->title, sizeof(existingNode->title));
+									}
+
 									if (!isStringEmpty(node->genre))
 									{
 										strncpy(existingNode->genre, node->genre, MAX_GENRE_NAME_SIZE);
@@ -982,8 +1013,12 @@ static BOOL examineFolder(char *path)
 								free(igameDataPath);
 							}
 
-							// Generate title and add in the list
-							generateItemName(existingNode->path, existingNode->title, sizeof(existingNode->title));
+							// If the current scan settings are different from last scan settings and
+							// the igame.data file is not used, get the title from the file
+							if (!current_settings->useIgameDataTitle && current_settings->lastScanSetup != calcLastScanBitfield())
+							{
+								generateItemName(existingNode->path, existingNode->title, sizeof(existingNode->title));
+							}
 						}
 					}
 				}
@@ -1016,6 +1051,7 @@ void scan_repositories(void)
 		showSlavesList();
 		populateGenresList();
 		populateChipsetList();
+		setLastScanBitfield();
 		set(app->WI_MainWindow, MUIA_Window_Sleep, FALSE);
 	}
 }
@@ -1639,6 +1675,8 @@ void settings_save(void)
 	snprintf(file_line, buffer_size, "screenshot_height=%d\n", current_settings->screenshot_height);
 	FPuts(fpsettings, (CONST_STRPTR)file_line);
 	snprintf(file_line, buffer_size, "use_igame.data_title=%d\n", current_settings->useIgameDataTitle);
+	FPuts(fpsettings, (CONST_STRPTR)file_line);
+	snprintf(file_line, buffer_size, "last_scan_setup=%d\n", current_settings->lastScanSetup);
 	FPuts(fpsettings, (CONST_STRPTR)file_line);
 
 	Close(fpsettings);

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -747,9 +747,9 @@ static void generateItemName(char *path, char *result, int resultSize)
 	}
 }
 
-static uint8_t calcLastScanBitfield(void)
+static int calcLastScanBitfield(void)
 {
-	uint8_t scanBitfield = 0;
+	int scanBitfield = 0;
 	scanBitfield = 1 * current_settings->useIgameDataTitle;
 	scanBitfield += 2 * current_settings->titles_from_dirs;
 	if(current_settings->titles_from_dirs)

--- a/src/iGameExtern.h
+++ b/src/iGameExtern.h
@@ -85,7 +85,7 @@ typedef struct settings
 	int no_guigfx;
 	int start_with_favorites;
 	int useIgameDataTitle;
-	uint8_t lastScanSetup;  // It keeps info of the settings on the last scan
+	int lastScanSetup;  // It keeps info of the settings on the last scan
 							// that influence the item data
 							// It is a bitfield with the following structure
 							//  ------------ no_smart_spaces

--- a/src/iGameExtern.h
+++ b/src/iGameExtern.h
@@ -85,6 +85,14 @@ typedef struct settings
 	int no_guigfx;
 	int start_with_favorites;
 	int useIgameDataTitle;
+	uint8_t lastScanSetup;  // It keeps info of the settings on the last scan
+							// that influence the item data
+							// It is a bitfield with the following structure
+							//  ------------ no_smart_spaces
+							//  |  --------- titles_from_dirs
+							//  |  |  ------ useIgameDataTitle
+							//  |  |  |
+							//  0  0  0
 } igame_settings;
 
 typedef struct genresList


### PR DESCRIPTION
This PR is about fixing #215  
Also, if the user scans the repositories and then change the way of discovering the titles from the settings, and the rescans, the titles are changed, except those that were renamed manually from the item properties window