### PR TITLE
Morphos fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Added
 - Added the "Open game folder" menu in the MorphOS version, that was missing
 
+### Changed
+- Disabled the gamepad usage on MorphOS because it was reported giving problems while playing a game
+
 ### Fixed
 - Fixed starting WHDLoad games in MorphOS using WHDLoadopener
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
 ### Added
+- Added the "Open game folder" menu in the MorphOS version, that was missing
+
+### Fixed
+- Fixed starting WHDLoad games in MorphOS using WHDLoadopener
+
+## iGame 2.5.0 - [2025-05-12]
+### Added
 - Added a new "Information" window that includes the "Released date", the "Released by", the "Chipset", the links to external websites and most of the fields from the properties window.
 - Added the option to use repositories based on assigns (fixes #240)
 

--- a/src/WinInfo.c
+++ b/src/WinInfo.c
@@ -24,7 +24,7 @@
 #include <libraries/mui.h>
 #include <mui/Urltext_mcc.h>
 
-#ifdef __MORPHOS__
+#ifdef __morphos__
 #define SDI_TRAP_LIB
 #endif
 #include <SDI_hook.h>

--- a/src/fsfuncs.c
+++ b/src/fsfuncs.c
@@ -451,11 +451,13 @@ void open_current_dir(void)
 	char *buf = AllocVec(bufSize, MEMF_CLEAR);
 	char *game_title = NULL;
 
+#if !defined(__morphos__)
 	if (get_wb_version() < 44)
 	{
 		// workbench.library doesn't support OpenWorkbenchObjectA yet
 		return;
 	}
+#endif
 
 	// Get the selected item from the list
 	DoMethod(app->LV_GamesList, MUIM_NList_GetEntry, MUIV_NList_GetEntry_Active, &game_title);
@@ -480,7 +482,15 @@ void open_current_dir(void)
 	}
 
 	// Open path directory on workbench
+#if defined(__morphos__)
+	int execSize = sizeof(char) * MAX_EXEC_SIZE;
+	char *exec = AllocVec(execSize, MEMF_CLEAR);
+	snprintf(exec, execSize, "open %s", buf);
+	Execute(exec, 0, 0);
+	FreeVec(exec);
+#else
 	OpenWorkbenchObject(buf);
+#endif
 	FreeVec(buf);
 }
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -486,12 +486,18 @@ static void launchSlave(slavesList *node)
 
 					// Get the slave filename
 					getNameFromPath(node->path, buf, bufSize);
+#if !defined(__morphos__)
 					if (checkSlaveInTooltypes(infoPath, buf))
 					{
+#endif
 						int execSize = sizeof(char) * MAX_EXEC_SIZE;
 						char *exec = AllocVec(execSize, MEMF_CLEAR);
-						prepareWHDExecution(infoPath, exec);
 
+#if defined(__morphos__)
+						snprintf(exec, execSize, "open %s", buf);
+#else
+						prepareWHDExecution(infoPath, exec);
+#endif
 						// Update statistics info
 						node->last_played = 1;
 						node->times_played++;
@@ -506,7 +512,9 @@ static void launchSlave(slavesList *node)
 
 						FreeVec(exec);
 						break;
+#if !defined(__morphos__)
 					}
+#endif
 				}
 			}
 

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -576,7 +576,7 @@ struct ObjApp *CreateApp(void)
 
 	MNMainOpenCurrentDir = MenuitemObject,
 		MUIA_Menuitem_Title, GetMBString(MSG_MNMainOpenCurrentDir),
-		//MUIA_Menuitem_Shortcut, GetMBString(MSG_MNMainOpenCurrentDirChar),
+		MUIA_Menuitem_Shortcut, MENU_DELETE_HOTKEY,
 		End;
 #endif // ndef __MORPHOS__
 
@@ -599,6 +599,7 @@ struct ObjApp *CreateApp(void)
 		MUIA_Menuitem_Title, GetMBString(MSG_MNlabel2Game),
 		MUIA_Family_Child, MNMainProperties,
 		MUIA_Family_Child, MNMainIformation,
+		MUIA_Family_Child, MNMainOpenCurrentDir,
 		End;
 
 	MNMainiGameSettings = MenuitemObject,

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -26,7 +26,7 @@
 #include <mui/TextEditor_mcc.h>
 #include <mui/NListview_mcc.h>
 
-#ifdef __MORPHOS__
+#ifdef __morphos__
 #define SDI_TRAP_LIB
 #endif
 #include <SDI_hook.h>
@@ -71,14 +71,14 @@
 extern igame_settings *current_settings;
 extern blockGuiGfx;
 
-#ifndef __MORPHOS__
+#ifndef __morphos__
 static void translateMenu(struct NewMenu *);
 static void flagMenuItem(struct NewMenu *, APTR, UWORD);
 
 #define TICK (CHECKIT|MENUTOGGLE)
 #define DIS  NM_ITEMDISABLED
 #define STR_ID(x) ( (STRPTR)(x) )
-#endif // ndef __MORPHOS__
+#endif // ndef __morphos__
 
 #if defined(__amigaos4__)
 #define AllocVecShared(size, flags)  AllocVecTags((size), AVT_Type, MEMF_SHARED, AVT_Lock, FALSE, ((flags)&MEMF_CLEAR) ? AVT_ClearWithValue : TAG_IGNORE, 0, TAG_DONE)
@@ -86,7 +86,7 @@ static void flagMenuItem(struct NewMenu *, APTR, UWORD);
 #define AllocVecShared(size, flags)  AllocVec((size), (flags))
 #endif
 
-#ifndef __MORPHOS__
+#ifndef __morphos__
 static struct NewMenu MenuMainWin[] =
 {
 	{ NM_TITLE, STR_ID(MSG_MNlabel2Actions)							, 0 ,0 ,0			,(APTR)MENU_ACTIONS },
@@ -111,7 +111,7 @@ static struct NewMenu MenuMainWin[] =
 
 	{ NM_END,NULL,0,0,0,NULL }
 };
-#endif // ndef __MORPHOS__
+#endif // ndef __morphos__
 
 static struct Listentry
 {
@@ -243,10 +243,10 @@ struct ObjApp *CreateApp(void)
 	static char about_text[512];
 	static char version_string[30];
 
-#ifndef __MORPHOS__
+#ifndef __morphos__
 	APTR strip;
 	translateMenu(MenuMainWin);
-#endif // ndef __MORPHOS__
+#endif // ndef __morphos__
 
 	snprintf(version_string, sizeof(version_string),
 		"%s %d.%d.%d (%s)",
@@ -259,13 +259,13 @@ struct ObjApp *CreateApp(void)
 		version_string, GetMBString(MSG_compiledForAboutWin), STR(CPU_VERS), COPY_END_YEAR, GetMBString(MSG_TX_About)
 	);
 
-#ifdef __MORPHOS__
+#ifdef __morphos__
 	APTR	MNlabel2Actions, MNlabelScan, MNMainAddnonWHDLoadgame, MNMainMenuShowHidehiddenentries;
 	APTR	MNMainBarLabel0, MNMainAbout;
 	APTR	MNMainBarLabel1, MNMainQuit, MNlabel2Game, MNMainProperties, MNMainIformation, MNMainOpenCurrentDir;
 	APTR	MNlabel2Tools, MNMainiGameSettings;
 	APTR	MNlabel2GameRepositories, MNMainBarLabel2, MNMainMUISettings;
-#endif // ndef __MORPHOS__
+#endif // ndef __morphos__
 
 	APTR	MNMainOpenList, MNMainSaveList, MNMainSaveListAs;
 	// APTR	MNMainMenuDuplicate;
@@ -504,7 +504,7 @@ struct ObjApp *CreateApp(void)
 		Child, object->TX_Status,
 		End;
 
-#ifdef __MORPHOS__
+#ifdef __morphos__
 	MNlabelScan = MenuitemObject,
 		MUIA_Menuitem_Title, GetMBString(MSG_MNlabelScan),
 		MUIA_Menuitem_Shortcut, MENU_SCANREPOS_HOTKEY,
@@ -534,7 +534,7 @@ struct ObjApp *CreateApp(void)
 		MUIA_Menuitem_Title, GetMBString(MSG_MNMainSaveListAs),
 		End;
 
-#ifdef __MORPHOS__
+#ifdef __morphos__
 	MNMainBarLabel0 = MUI_MakeObject(MUIO_Menuitem, NM_BARLABEL, 0, 0, 0);
 
 	MNMainAbout = MenuitemObject,
@@ -578,7 +578,7 @@ struct ObjApp *CreateApp(void)
 		MUIA_Menuitem_Title, GetMBString(MSG_MNMainOpenCurrentDir),
 		MUIA_Menuitem_Shortcut, MENU_DELETE_HOTKEY,
 		End;
-#endif // ndef __MORPHOS__
+#endif // ndef __morphos__
 
 	// MNMainMenuDuplicate = MenuitemObject,
 	// 	MUIA_Menuitem_Title, GetMBString(MSG_MNMainMenuDuplicate),
@@ -589,7 +589,7 @@ struct ObjApp *CreateApp(void)
 	// 	MUIA_Menuitem_Shortcut, MENU_DELETE_HOTKEY,
 	// 	End;
 
-#ifndef __MORPHOS__
+#ifndef __morphos__
 	if (get_wb_version() < 44)
 	{
 		flagMenuItem(MenuMainWin, (APTR)MENU_GAMEFOLDER, DIS);
@@ -629,16 +629,16 @@ struct ObjApp *CreateApp(void)
 		MUIA_Family_Child, MNlabel2Game,
 		MUIA_Family_Child, MNlabel2Tools,
 		End;
-#endif // ndef __MORPHOS__
+#endif // ndef __morphos__
 
 	object->WI_MainWindow = WindowObject,
 		MUIA_Window_ScreenTitle, version_string,
 		MUIA_Window_Title, GetMBString(MSG_WI_MainWindow),
-#ifndef __MORPHOS__
+#ifndef __morphos__
 		MUIA_Window_Menustrip, strip = MUI_MakeObject(MUIO_MenustripNM, MenuMainWin, 0),
 #else
 		MUIA_Window_Menustrip, object->MN_MainMenu,
-#endif // ndef __MORPHOS__
+#endif // ndef __morphos__
 		MUIA_Window_ID, MAKE_ID('0', 'I', 'G', 'A'),
 		MUIA_Window_AppWindow, TRUE,
 		WindowContents, GROUP_ROOT,
@@ -1588,7 +1588,7 @@ struct ObjApp *CreateApp(void)
 		0
 	);
 
-#ifdef __MORPHOS__
+#ifdef __morphos__
 	DoMethod(MNlabelScan,
 		MUIM_Notify, MUIA_Menuitem_Trigger, MUIV_EveryTime,
 		object->App,

--- a/src/iGameMain.c
+++ b/src/iGameMain.c
@@ -200,7 +200,7 @@ int main(int argc, char **argv)
 		}
 
 		// TODO: This doesn't work on AmigaOS 4. Needs to be updated with compatible code
-		#if !defined(__amigaos4__)
+		#if !defined(__amigaos4__) && !defined(__morphos__)
 		if (LowLevelBase)
 		{
 			const ULONG new = ReadJoyPort(unit);
@@ -263,7 +263,7 @@ static int initLibraries(void)
 {
 	if ((MUIMasterBase = OpenLibrary(MUIMASTER_NAME, 19)))
 	{
-		#ifdef __amigaos4__
+		#if defined(__amigaos4__)
 		IMUIMaster = (struct MUIMasterIFace *)GetInterface(MUIMasterBase, "main", 1, NULL);
 		if(!IMUIMaster) return clean_exit("Can't open muimaster Interface\n");
 		#endif


### PR DESCRIPTION
### Added
- Added the "Open game folder" menu in the MorphOS version, that was missing

### Changed
- Disabled the gamepad usage on MorphOS because it was reported giving problems while playing a game

### Fixed
- Fixed starting WHDLoad games in MorphOS using WHDLoadopener