### PR TITLE
Fixed the execution of whdload that broke on v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
+### Fixed
+- Fixed the execution of whdload that broke on v2.5.1 for those that use an old icon library
+
+## iGame 2.5.1 - [2025-05-29]
 ### Added
 - Added a file requester in the Properties window, which can be used to set a different WHDLoad slave file for an item. This is useful when a game/demo changed place on the hard disk. (#174)
 - Based on the selected file by the new field, the tooltypes text is updated, enabled/disabled, based if the selected file is a WHDLoad slave one.

--- a/src/fsfuncs.c
+++ b/src/fsfuncs.c
@@ -509,7 +509,7 @@ BOOL isPathFolder(char *path)
 */
 void getIconTooltypes(char *path, char *result)
 {
-	if (IconBase && (IconBase->lib_Version >= 44))
+	if (IconBase)
 	{
 		struct DiskObject *diskObj = GetDiskObjectNew(path);
 		if(diskObj)


### PR DESCRIPTION
Fixed the execution of whdload that broke on v2.5.1 for those that use an old icon library