### PR TITLE
Genres lists enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
+### Added
+- By changing the Genre select box to a PopupString, it is now possible to edit the Genre title and create new ones, which will be added in the Genre lists
+
+### Changed
+- The genres in the Information window changed to a PopupString. Now, it takes less space to choose a genre, making it possible even on small resolutions.
+- The genres lists have the titles sorted alphabetically
+- Removed some not necessary fill ups of genre cycle boxes and loops. This should make iGame start a little bit faster
+- Removed some extra change notifications in Genres lists, which should avoid not necessary refreshes of the games/demos lists
+
+### Fixed
+- The genres lists were not populated when the right sidebar was disabled (#260)
+
+## iGame 2.5.2 - [2025-05-31]
 ### Fixed
 - Fixed the execution of whdload that broke on v2.5.1 for those that use an old icon library
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
 ### Added
-- By changing the Genre select box to a PopupString, it is now possible to edit the Genre title and create new ones, which will be added in the Genre lists
+- By changing the Genre select box to a PopupString, it is now possible to edit the Genre title and create new ones, which will be added to the Genre lists
 
 ### Changed
 - The genres in the Information window changed to a PopupString. Now, it takes less space to choose a genre, making it possible even on small resolutions.

--- a/required_files/iGame.guide
+++ b/required_files/iGame.guide
@@ -296,7 +296,7 @@ This window opens from the menu item "Game > Information". For this to work you 
 
 From the top, the first field is the entry title, which you can change if you like.
 
-Next, you can set the Genre from the select list. This can be used from the Genres list on the right side of the main window.
+Next, you can select the Genre from the selection list or you can create a new one. If the selected genre does not exist in the genres lists, a new option will be added. This can be used from the genres list on the right side of the main window and in the "Information" and the "Add game" windows.
 
 Following, on the left side, there is some information that is not editable. There you will see the "Release year", the "Released by" entry that shows who released this game/demo, the required "Chipset", the "No. of players" that the game supports and the number of times this game was played.
 

--- a/src/WinInfo.c
+++ b/src/WinInfo.c
@@ -32,6 +32,7 @@
 /* Prototypes */
 #include <clib/alib_protos.h>
 #include <proto/muimaster.h>
+#include <string.h>
 
 #define iGame_NUMBERS
 #include "iGame_strings.h"
@@ -43,6 +44,38 @@
 #include "WinInfo.h"
 
 extern igame_settings *current_settings;
+
+HOOKPROTONH(StrObjFunc, int, Object *popObject, Object *strObject)
+{
+	char *listEntry, *currentGenre;
+	get(strObject, MUIA_String_Contents, &currentGenre);
+
+	for (int i=0;;i++)
+	{
+		DoMethod(popObject, MUIM_List_GetEntry, i, &listEntry);
+		if (!listEntry)
+		{
+			set(popObject, MUIA_List_Active, MUIV_List_Active_Off);
+			break;
+		}
+		else if (!strcmp(listEntry, currentGenre))
+		{
+			set(popObject, MUIA_List_Active, i);
+			DoMethod(popObject, MUIM_List_Jump, MUIV_List_Jump_Active);
+			break;
+		}
+	}
+	return(TRUE);
+}
+MakeStaticHook(StrObjHook, StrObjFunc);
+
+HOOKPROTONH(ObjStrFunc, int, Object *popObject, Object *strObject)
+{
+	char *selectedGenre;
+	DoMethod(popObject, MUIM_List_GetEntry, MUIV_List_GetEntry_Active, &selectedGenre);
+	set(strObject, MUIA_String_Contents, selectedGenre);
+}
+MakeStaticHook(ObjStrHook, ObjStrFunc);
 
 APTR getInformationWindow(struct ObjApp *object)
 {
@@ -83,13 +116,35 @@ APTR getInformationWindow(struct ObjApp *object)
 		MUIA_Window_ID, MAKE_ID('6', 'I', 'G', 'A'),
 		MUIA_HelpNode, "WININFO",
 		WindowContents, VGroup,
+			Child, TextObject,
+				MUIA_Weight, 30,
+				MUIA_Text_PreParse, "\0338",
+				MUIA_Text_Contents, GetMBString(MSG_STR_PropertiesGameTitleTitle),
+				MUIA_InnerLeft, 0,
+				MUIA_InnerRight, 0,
+			End,
 			Child, object->STR_WI_Information_Title = StringObject,
 				MUIA_Frame, MUIV_Frame_String,
 			End,
+			Child, TextObject,
+				MUIA_Weight, 30,
+				MUIA_Text_PreParse, "\0338",
+				MUIA_Text_Contents, GetMBString(MSG_LA_PropertiesGenre),
+				MUIA_InnerLeft, 0,
+				MUIA_InnerRight, 0,
+			End,
 			Child, GroupObject,
-				Child, object->CY_WI_Information_Genre = CycleObject,
-					MUIA_Frame, MUIV_Frame_Button,
-					MUIA_Cycle_Entries, object->CY_PropertiesGenreContent,
+				Child, object->POP_WI_Information_Genre = PopobjectObject,
+					MUIA_Popstring_String, object->STR_WI_Information_Genre = KeyString(0, MAX_GENRE_NAME_SIZE, 'n'),
+					MUIA_Popstring_Button, PopButton(MUII_PopUp),
+					MUIA_Popobject_StrObjHook, &StrObjHook,
+					MUIA_Popobject_ObjStrHook, &ObjStrHook,
+					MUIA_Popobject_Object, object->LV_WI_Information_Genre = ListviewObject,
+						MUIA_Listview_List, ListObject,
+							InputListFrame,
+							MUIA_List_AutoVisible, TRUE,
+							End,
+						End,
 				End,
 			End,
 			Child, ColGroup(2),
@@ -208,9 +263,14 @@ void setInformationWindowMethods(struct ObjApp *object)
 
 	DoMethod(object->WI_Information,
 		MUIM_Notify, MUIA_Window_CloseRequest, TRUE,
-		object->WI_Information,
-		3,
+		MUIV_Notify_Self, 3,
 		MUIM_Set, MUIA_Window_Open, FALSE
+	);
+
+	DoMethod(object->WI_Information,
+		MUIM_Notify, MUIA_Window_Open, FALSE,
+		object->POP_WI_Information_Genre, 2,
+		MUIM_Popstring_Close, TRUE
 	);
 
 	DoMethod(
@@ -232,5 +292,12 @@ void setInformationWindowMethods(struct ObjApp *object)
 		MUIM_Notify, MUIA_Pressed, FALSE,
 		object->WI_Information, 3,
 		MUIM_Set, MUIA_Window_Open, FALSE
+	);
+
+	DoMethod(
+		object->LV_WI_Information_Genre,
+		MUIM_Notify, MUIA_List_DoubleClick, TRUE,
+		object->POP_WI_Information_Genre, 2,
+		MUIM_Popstring_Close, TRUE
 	);
 }

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -2092,7 +2092,7 @@ void saveItemInformation(void)
 	// Update the genre and if it is a new one, add it to the genres list
 	get(app->STR_WI_Information_Genre, MUIA_String_Contents, &buf);
 	strlcpy(node->genre, buf, sizeof(node->genre));
-	genresList *newGenrePtr = addGenreInList(buf)
+	genresList *newGenrePtr = addGenreInList(buf);
 	if (newGenrePtr != NULL)
 	{
 		if (!current_settings->hide_side_panel)

--- a/src/genresList.c
+++ b/src/genresList.c
@@ -86,7 +86,7 @@ void genresListPrint(void)
 	printf("END OF LIST: %d items\n", cnt);
 }
 
-genresList *genresListSearchByTitle(char *title, unsigned int titleSize)
+genresList *genresListSearchByTitle(const char *title, unsigned int titleSize)
 {
 	if (isListEmpty(genresListHead))
 	{
@@ -128,19 +128,61 @@ int genresListNodeCount(int cnt)
 	return nodeCount;
 }
 
-void addGenreInList(char *title)
+genresList *addGenreInList(const char *title)
 {
 	if (isStringEmpty(title))
-		return;
+		return NULL;
 
 	if (genresListSearchByTitle(title, sizeof(char) * MAX_GENRE_NAME_SIZE) == NULL)
 	{
 		genresList *node = malloc(sizeof(genresList));
 		if(node == NULL)
 		{
-			return;
+			return NULL;
 		}
 		strncpy(node->title, title, sizeof(char) * MAX_GENRE_NAME_SIZE);
 		genresListAddTail(node);
+		return node;
 	}
+	return NULL;
+}
+
+void sortGenresList(void)
+{
+	if (isListEmpty(genresListHead) || genresListHead->next == NULL) {
+		// Empty list or single node - already sorted
+		return;
+	}
+
+	genresList *sorted = NULL;
+	genresList *current = genresListHead;
+
+	// Remove each node from original list and insert into sorted list
+	while (current != NULL) {
+		// Save next node before we detach current
+		genresList *next = current->next;
+
+		// Insert current node into sorted list in correct position
+		if (sorted == NULL || strncmp(current->title, sorted->title, MAX_GENRE_NAME_SIZE) <= 0) {
+			// Insert at beginning of sorted list
+			current->next = sorted;
+			sorted = current;
+		} else {
+			// Find insertion point in sorted list
+			genresList *search = sorted;
+			while (search->next != NULL &&
+				   strncmp(current->title, search->next->title, MAX_GENRE_NAME_SIZE) > 0) {
+				search = search->next;
+			}
+			// Insert after search node
+			current->next = search->next;
+			search->next = current;
+		}
+
+		// Move to next node in original list
+		current = next;
+	}
+
+	// Update head pointer
+	genresListHead = sorted;
 }

--- a/src/genresList.h
+++ b/src/genresList.h
@@ -25,10 +25,11 @@
 
 void genresListAddTail(genresList *);
 void genresListPrint(void);
-genresList *genresListSearchByTitle(char *, unsigned int);
+genresList *genresListSearchByTitle(const char *, unsigned int);
 genresList *getGenresListHead(void);
 void emptyGenresList(void);
 int genresListNodeCount(int);
-void addGenreInList(char *);
+genresList *addGenreInList(const char *);
+void sortGenresList(void);
 
 #endif

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -329,8 +329,8 @@ struct ObjApp *CreateApp(void)
 
 	object->STR_TX_About = about_text;
 
-	object->CY_PropertiesGenreContent[0] = (CONST_STRPTR)GetMBString(MSG_CY_PropertiesGenre0);
-	object->CY_PropertiesGenreContent[1] = NULL;
+	object->GenresContent[0] = (CONST_STRPTR)GetMBString(MSG_CY_PropertiesGenre0);
+	object->GenresContent[1] = NULL;
 
 	object->CY_ScreenshotSizeContent[0] = (CONST_STRPTR)GetMBString(MSG_CY_ScreenshotSize0);
 	object->CY_ScreenshotSizeContent[1] = (CONST_STRPTR)GetMBString(MSG_CY_ScreenshotSize1);
@@ -751,7 +751,6 @@ struct ObjApp *CreateApp(void)
 	object->CY_AddGameGenre = CycleObject,
 		MUIA_HelpNode, "CY_AddGameGenre",
 		MUIA_Frame, MUIV_Frame_Button,
-		MUIA_Cycle_Entries, object->CY_PropertiesGenreContent,
 		End;
 
 	GR_AddGameGenre = GroupObject,
@@ -1158,7 +1157,6 @@ struct ObjApp *CreateApp(void)
 
 	//call whenever the string is changed
 	if (!current_settings->filter_use_enter) {
-
 		DoMethod(object->STR_Filter,
 			MUIM_Notify, MUIA_String_Contents, MUIV_EveryTime,
 			object->App,
@@ -1206,7 +1204,7 @@ struct ObjApp *CreateApp(void)
 
 	DoMethod(object->LV_GenresList,
 		MUIM_Notify, MUIA_List_Active, MUIV_EveryTime,
-		object->LV_GenresList,
+		MUIV_Notify_Self,
 		2,
 		MUIM_CallHook, &GenreClickHook
 	);

--- a/src/iGameGUI.h
+++ b/src/iGameGUI.h
@@ -92,7 +92,7 @@ struct ObjApp
 	CONST_STRPTR STR_TX_PropertiesSlavePath;
 	CONST_STRPTR STR_TX_PropertiesTooltypes;
 	CONST_STRPTR STR_TX_About;
-	CONST_STRPTR CY_PropertiesGenreContent[256];
+	CONST_STRPTR GenresContent[256];
 	CONST_STRPTR CY_ScreenshotSizeContent[4];
 	CONST_STRPTR RA_TitlesFromContent[3];
 	CONST_STRPTR CY_FilterListContent[6];
@@ -107,7 +107,9 @@ struct ObjApp
 	APTR TX_WI_Information_TimesPlayed;
 	APTR CH_WI_Information_Favourite;
 	APTR CH_WI_Information_Hidden;
-	APTR CY_WI_Information_Genre;
+	APTR POP_WI_Information_Genre;
+	APTR STR_WI_Information_Genre;
+	APTR LV_WI_Information_Genre;
 	APTR GR_WI_Information_Links;
 	APTR URL_WI_Information_Lemonamiga;
 	APTR URL_WI_Information_HOL;


### PR DESCRIPTION
With these PR I changed a lot the logic of Genre loading and selection

### Added
- By changing the Genre select box to a PopupString, it is now possible to edit the Genre title and create new ones, which will be added to the Genre lists

### Changed
- The genres in the Information window changed to a PopupString. Now, it takes less space to choose a genre, making it possible even on small resolutions.
- The genres lists have the titles sorted alphabetically
- Removed some not necessary fill ups of genre cycle boxes and loops. This should make iGame start a little bit faster
- Removed some extra change notifications in Genres lists, which should avoid not necessary refreshes of the games/demos lists

### Fixed
- The genres lists were not populated when the right sidebar was disabled (#260)

![Screenshot From 2025-06-08 12-56-12](https://github.com/user-attachments/assets/0c74f952-6b08-4349-a0cd-1309cf1f8a49)

