### PR TITLE
Fix images and repo scanning on MorphOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## iGame VERSION_TAG - [RELEASE_DATE]
+### Fixed
+- Fixed the screenshots being visible for the selected entry on MorphOS (#255)
+- Fixed duplicate records in list when the repository was scanned repeatedly, and the igame.data files were used. This was surfaced only on MorphOS, but could be a potential problem on other systems as well (#265)
+
+## iGame 2.6.0 - [2025-06-14]
 ### Added
 - By changing the Genre select box to a PopupString, it is now possible to edit the Genre title and create new ones, which will be added to the Genre lists
 - Added Portuguese language

--- a/src/WinProps.c
+++ b/src/WinProps.c
@@ -24,7 +24,7 @@
 #include <libraries/mui.h>
 #include <mui/TextEditor_mcc.h>
 
-#ifdef __MORPHOS__
+#ifdef __morphos__
 #define SDI_TRAP_LIB
 #endif
 #include <SDI_hook.h>

--- a/src/fsfuncs.c
+++ b/src/fsfuncs.c
@@ -678,59 +678,42 @@ void getIGameDataInfo(char *igameDataPath, slavesList *node)
 	{
 		int lineSize = 64;
 		char *line = malloc(lineSize * sizeof(char));
-		while (FGets(fpigamedata, line, lineSize) != NULL)
+		while (FGets(fpigamedata, line, lineSize))
 		{
-			char **tokens = str_split(line, '=');
-			if (tokens)
+			char *key = strtok(line, "=");
+			char *value = strtok(NULL, "\n");
+
+			if (key && value && strlen(value) > 0)
 			{
-				if (tokens[1] != NULL)
+				if(current_settings->useIgameDataTitle && !strcmp(key, "title"))
 				{
-					int tokenValueLen = strlen(tokens[1]);
-					if (tokens[1][tokenValueLen - 1] == '\n')
-					{
-						tokens[1][tokenValueLen - 1] = '\0';
-					}
-					else
-					{
-						tokens[1][tokenValueLen] = '\0';
-					}
-
-					if(current_settings->useIgameDataTitle && !strcmp(tokens[0], "title"))
-					{
-						strncpy(node->title, tokens[1], MAX_SLAVE_TITLE_SIZE);
-					}
-
-					if(!strcmp(tokens[0], "chipset"))
-					{
-						strncpy(node->chipset, tokens[1], MAX_CHIPSET_SIZE);
-					}
-
-					if(!strcmp(tokens[0], "genre"))
-					{
-						strncpy(node->genre, tokens[1], MAX_GENRE_NAME_SIZE);
-					}
-
-					if(!strcmp(tokens[0], "year") && isNumeric(tokens[1]))
-					{
-						node->year=atoi(tokens[1]);
-					}
-
-					if(!strcmp(tokens[0], "players") && isNumeric(tokens[1]))
-					{
-						node->players=atoi(tokens[1]);
-					}
-
-					if(!strcmp(tokens[0], "exe") && !isStringEmpty(tokens[1]) && !strcasestr(tokens[1], ".slave"))
-					{
-						strncpy(node->path, tokens[1], MAX_PATH_SIZE);
-					}
+					strncpy(node->title, value, MAX_SLAVE_TITLE_SIZE);
 				}
-				int i;
-				for (i = 0; *(tokens + i); i++)
+
+				if(!strcmp(key, "chipset"))
 				{
-					free(*(tokens + i));
+					strncpy(node->chipset, value, MAX_CHIPSET_SIZE);
 				}
-				free(tokens);
+
+				if(!strcmp(key, "genre"))
+				{
+					strncpy(node->genre, value, MAX_GENRE_NAME_SIZE);
+				}
+
+				if(!strcmp(key, "year") && isNumeric(value))
+				{
+					node->year=atoi(value);
+				}
+
+				if(!strcmp(key, "players") && isNumeric(value))
+				{
+					node->players=atoi(value);
+				}
+
+				if(!strcmp(key, "exe") && !isStringEmpty(value) && !strcasestr(value, ".slave"))
+				{
+					strncpy(node->path, value, MAX_PATH_SIZE);
+				}
 			}
 		}
 

--- a/src/funcs.c
+++ b/src/funcs.c
@@ -857,6 +857,7 @@ static BOOL examineFolder(char *path)
 						node->deleted = 0;
 						node->year = 0;
 						node->players = 0;
+						node->path[0] = '\0';
 
 						getIGameDataInfo(igameDataPath, node);
 						free(igameDataPath);
@@ -917,7 +918,7 @@ static BOOL examineFolder(char *path)
 							node->instance = 0;
 							node->title[0] = '\0';
 							node->genre[0] = '\0';
-							sprintf(node->genre,"Unknown");
+							sprintf(node->genre, "Unknown");
 							node->user_title[0] = '\0';
 							node->chipset[0] = '\0';
 							node->times_played = 0;
@@ -928,6 +929,7 @@ static BOOL examineFolder(char *path)
 							node->deleted = 0;
 							node->year = 0;
 							node->players = 0;
+							node->path[0] = '\0';
 
 							getFullPath(buf, buf);
 							strncpy(node->path, buf, sizeof(node->path));
@@ -998,6 +1000,7 @@ static BOOL examineFolder(char *path)
 									node->deleted = 0;
 									node->year = 0;
 									node->players = 0;
+									node->path[0] = '\0';
 
 									getIGameDataInfo(igameDataPath, node);
 
@@ -1201,12 +1204,14 @@ static void get_screenshot_path(char *game_title, char *result)
 
 		// Return the slave icon from the game folder, if exists
 		// TODO: Check if this item is a slave. If not don't use the substring
+#if !defined(__morphos__)
 		snprintf(result, sizeof(char) * MAX_PATH_SIZE, "%s.info", substring(existingNode->path, 0, -6));
 		if(checkImageDatatype(result))
 		{
 			free(buf);
 			return;
 		}
+#endif
 
 		// Return the default image from iGame folder, if exists
 		if(check_path_exists(DEFAULT_SCREENSHOT_FILE))
@@ -1725,6 +1730,7 @@ void non_whdload_ok(void)
 	node->deleted = 0;
 	node->year = 0;
 	node->players = 0;
+	node->path[0] = '\0';
 
 	get(app->PA_AddGame, MUIA_String_Contents, &path);
 	getFullPath(path, node->path);

--- a/src/iGameGUI.c
+++ b/src/iGameGUI.c
@@ -1543,6 +1543,10 @@ BOOL checkImageDatatype(STRPTR filename)
 
 	if((lock = Lock(filename, SHARED_LOCK)))
 	{
+#if defined(__morphos__)
+		UnLock(lock);
+		return TRUE; // MorphOS includes the ilbm datatype by default
+#endif
 		if((dtn = ObtainDataType(DTST_FILE, (APTR)lock, TAG_END)))
 		{
 			const struct DataTypeHeader *dth = dtn->dtn_Header;


### PR DESCRIPTION
### Fixed
- Fixed the screenshots being visible for the selected entry on MorphOS (#255)
- Fixed duplicate records in list when the repository was scanned repeatedly, and the igame.data files were used. This was surfaced only on MorphOS, but could be a potential problem on other systems as well (#265)